### PR TITLE
Dev UI rework

### DIFF
--- a/src-tauri/src/device/manager.rs
+++ b/src-tauri/src/device/manager.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
 use semver::Version;
-use tauri::AppHandle;
+use tauri::{AppHandle, Emitter};
 
 use crate::serial::{SerialInterface, ConfigProtocol, StorageInfo};
 use crate::serial::unified::reader::UnifiedSerialHandle;
@@ -24,6 +24,9 @@ pub struct DeviceManager {
     app_handle: Arc<Mutex<Option<AppHandle>>>,
     raw_monitoring_active: Arc<AtomicBool>,
     unified_handles: Arc<Mutex<HashMap<Uuid, UnifiedSerialHandle>>>,
+    key_to_id: Arc<Mutex<HashMap<String, Uuid>>>,
+    /// One-shot guarded initial discovery burst after app handle is set (bounded, not polling)
+    initial_discovery_started: Arc<AtomicBool>,
 }
 
 impl DeviceManager {
@@ -34,7 +37,16 @@ impl DeviceManager {
             // Return a reader that will work but won't be able to connect
             HidReader::new().expect("Second HID initialization attempt failed")
         });
-        
+    // NOTE: Architecture decisions:
+    // 1. No continuous polling for device discovery. Instead we perform explicit discover calls
+    //    plus a bounded one-shot burst on startup (see set_app_handle) to catch devices that
+    //    enumerate slightly after the UI loads. This respects the "no polling" constraint while
+    //    improving hot-plug detection at launch.
+    // 2. Connection events are standardized: { id, state, error? } with state in
+    //    [Connected, Connecting, Disconnected, Error]. All emissions flow through
+    //    update_device_connection_state to avoid duplicate or out-of-order UI updates.
+    // 3. Device list snapshots are emitted after each connection state change and discovery to
+    //    keep frontend authoritative without needing intervals.
         Self {
             devices: Arc::new(RwLock::new(HashMap::new())),
             connected_device: Arc::new(Mutex::new(None)),
@@ -43,7 +55,44 @@ impl DeviceManager {
             app_handle: Arc::new(Mutex::new(None)),
             raw_monitoring_active: Arc::new(AtomicBool::new(false)),
             unified_handles: Arc::new(Mutex::new(HashMap::new())),
+            key_to_id: Arc::new(Mutex::new(HashMap::new())),
+            initial_discovery_started: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Sanitize a firmware version string so it can be parsed as proper semver.
+    /// - Trims whitespace and any embedded NULs
+    /// - Splits on line breaks and takes the first non-empty line
+    /// - Removes trailing descriptive tokens after a space that are clearly not part of semver
+    /// - Strips stray carriage returns left in the middle
+    /// If the cleaned version still fails to parse, we leave the original so that
+    /// higher layers can decide how to handle it; but we attempt best-effort fix.
+    fn sanitize_firmware_version(raw: &str) -> String {
+        // Fast path: empty
+        if raw.is_empty() { return raw.to_string(); }
+        // Remove any embedded "\0" just in case, trim
+        let mut cleaned = raw.replace('\0', "");
+        // Normalize line endings then split
+        cleaned = cleaned.replace('\r', "\n");
+        let mut first_line = cleaned.lines().find(|l| !l.trim().is_empty()).unwrap_or("").trim().to_string();
+        // Some firmware appends markers like " GPIO_STATES" after the semver; drop after first space
+        if let Some(space_idx) = first_line.find(' ') { first_line = first_line[..space_idx].to_string(); }
+        // Remove any residual control chars
+        first_line.retain(|c| !c.is_control() || c == '\n');
+        // Final trim
+        first_line = first_line.trim().to_string();
+        // Validate basic semver shape (very lightweight): must contain a digit and a dot
+        if !first_line.is_empty() && first_line.chars().any(|c| c.is_ascii_digit()) && first_line.contains('.') {
+            // Attempt full semver parse (allow pre-release/build metadata)
+            if semver::Version::parse(&first_line).is_ok() {
+                return first_line;
+            }
+            // Try removing trailing non-semver characters (e.g., stray punctuation)
+            let trimmed = first_line.trim_end_matches(|c: char| !(c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '+'));
+            if trimmed != first_line && semver::Version::parse(trimmed).is_ok() { return trimmed.to_string(); }
+        }
+        // Fallback: original first line (or raw if first_line empty)
+        if first_line.is_empty() { raw.trim().to_string() } else { first_line }
     }
 
     pub async fn get_unified_serial_handle(&self) -> Option<crate::serial::unified::reader::UnifiedSerialHandle> {
@@ -72,140 +121,76 @@ impl DeviceManager {
                 log::info!("Started raw state monitoring after app handle was set");
             }
         }
+
+        // Bounded initial discovery burst (no continuous polling). Runs only once.
+        if !self.initial_discovery_started.swap(true, Ordering::SeqCst) {
+            let mgr = self.clone();
+            tokio::spawn(async move {
+                // Skip if we already have devices
+                if !mgr.get_devices().await.is_empty() { return; }
+                let attempts = 10u8; // ~2.5s worst-case (increasing backoff)
+                for i in 0..attempts {
+                    if let Err(e) = mgr.discover_devices().await { log::debug!("Startup discover attempt {} failed: {}", i, e); }
+                    if !mgr.get_devices().await.is_empty() { break; }
+                    // Exponential-ish backoff but capped
+                    let delay_ms = 100 + (i as u64 * 50);
+                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms.min(400))).await;
+                }
+            });
+        }
     }
 
     /// Discover available JoyCore devices
     pub async fn discover_devices(&self) -> Result<Vec<Device>> {
-        let serial_devices = SerialInterface::discover_devices()
-            .map_err(DeviceError::SerialError)?;
-
+        let serial_devices = SerialInterface::discover_devices().map_err(DeviceError::SerialError)?;
         let mut devices_guard = self.devices.write().await;
-        let mut discovered_devices = Vec::new();
+        let mut key_map = self.key_to_id.lock().await;
+        let mut seen_keys = std::collections::HashSet::new();
+        let mut result = Vec::new();
 
-        for serial_info in serial_devices {
-            // Create or update device entry
-            let device = Device::from_serial_info(&serial_info);
-            let device_id = device.id;
-            
-            // Check if we already know about this device (by port name)
-            let existing_device_id = devices_guard.values()
-                .find(|d| d.port_name == serial_info.port_name)
-                .map(|d| d.id);
-            
-            if let Some(existing_id) = existing_device_id {
-                // Update existing device info but preserve current connection state
-                let existing = devices_guard.get(&existing_id).unwrap().clone();
-                let mut updated_device = existing;
-                updated_device.serial_number = serial_info.serial_number;
-                updated_device.manufacturer = serial_info.manufacturer;
-                updated_device.product = serial_info.product;
-                updated_device.last_seen = chrono::Utc::now();
-                // Update device status with firmware version if we have it
-                if let Some(ref fw_version) = serial_info.firmware_version {
-                    if let Some(ref mut status) = updated_device.device_status {
-                        status.firmware_version = fw_version.clone();
+        for info in serial_devices {
+            let key = format!("{}:{}", info.port_name, info.serial_number.clone().unwrap_or_default());
+            seen_keys.insert(key.clone());
+            if let Some(id) = key_map.get(&key).cloned() {
+                if let Some(existing) = devices_guard.get_mut(&id) {
+                    existing.serial_number = info.serial_number.clone();
+                    existing.manufacturer = info.manufacturer.clone();
+                    existing.product = info.product.clone();
+                    existing.last_seen = chrono::Utc::now();
+                    if let Some(ref fw) = info.firmware_version { 
+                        if let Some(ref mut st) = existing.device_status { 
+                            let cleaned = Self::sanitize_firmware_version(fw);
+                            if cleaned != st.firmware_version { 
+                                log::debug!("Discovery sanitized firmware version '{}' -> '{}'", fw, cleaned);
+                                st.firmware_version = cleaned; 
+                            }
+                        }
                     }
+                    result.push(existing.clone());
                 }
-                // Keep existing connection state - don't reset to Disconnected
-                
-                devices_guard.insert(existing_id, updated_device.clone());
-                discovered_devices.push(updated_device);
             } else {
-                // Add new device
-                devices_guard.insert(device_id, device.clone());
-                discovered_devices.push(device);
+                let device = Device::from_serial_info(&info);
+                let id = device.id;
+                key_map.insert(key, id);
+                devices_guard.insert(id, device.clone());
+                result.push(device);
             }
         }
-
-        Ok(discovered_devices)
+        // Remove stale keys (disconnected devices) that vanished
+        let to_remove: Vec<Uuid> = key_map.iter()
+            .filter_map(|(k, id)| if !seen_keys.contains(k) { Some(*id) } else { None })
+            .collect();
+        for id in to_remove {
+            key_map.retain(|_, v| *v != id);
+            if let Some(mut d) = devices_guard.remove(&id) { d.update_connection_state(ConnectionState::Disconnected); }
+        }
+        drop(devices_guard);
+        self.emit_device_list().await;
+        Ok(result)
     }
 
     /// Clean up devices that are no longer present (separate from discovery)
-    pub async fn cleanup_disconnected_devices(&self) -> Result<Vec<Uuid>> {
-        let serial_devices = SerialInterface::discover_devices()
-            .map_err(DeviceError::SerialError)?;
-
-        let mut devices_guard = self.devices.write().await;
-        
-        // Get list of currently found port names
-        let found_ports: std::collections::HashSet<String> = serial_devices.iter()
-            .map(|info| info.port_name.clone())
-            .collect();
-
-        // Remove devices that are no longer present
-        let mut devices_to_remove = Vec::new();
-        let connected_device_id = {
-            let connected_guard = self.connected_device.lock().await;
-            connected_guard.as_ref().map(|(id, _)| *id)
-        };
-        
-        for (device_id, device) in devices_guard.iter() {
-            if !found_ports.contains(&device.port_name) {
-                match device.connection_state {
-                    // For connected devices, verify the connection is still active
-                    ConnectionState::Connected => {
-                        if let Some(connected_id) = connected_device_id {
-                            if connected_id == *device_id {
-                                // Try to verify if the connection is still active by checking the protocol
-                                let mut should_disconnect = false;
-                                {
-                                    let mut connected_guard = self.connected_device.lock().await;
-                                    if let Some((_, protocol)) = &mut *connected_guard {
-                                        // Try a simple status read to verify connection is still alive
-                                        if let Err(_) = protocol.get_device_status().await {
-                                            log::info!("Connected device {} failed status check - was physically disconnected", device.port_name);
-                                            should_disconnect = true;
-                                        }
-                                    } else {
-                                        should_disconnect = true;
-                                    }
-                                }
-                                
-                                if should_disconnect {
-                                    log::info!("Connected device {} was physically disconnected", device.port_name);
-                                    // Clear the connected device immediately
-                                    let mut connected_guard = self.connected_device.lock().await;
-                                    *connected_guard = None;
-                                    // Mark device for removal
-                                    devices_to_remove.push(*device_id);
-                                    continue;
-                                } else {
-                                    log::debug!("Connected device {} not found in discovery but status check successful, keeping it", device.port_name);
-                                    continue;
-                                }
-                            }
-                        }
-                        // If we get here, connected device is not the active one, remove it
-                        devices_to_remove.push(*device_id);
-                        log::info!("Marking connected device {} for removal (was physically disconnected)", device.port_name);
-                    },
-                    // Don't remove device if it's currently connecting (might be temporarily unavailable)
-                    ConnectionState::Connecting => {
-                        log::debug!("Device {} not found during cleanup but is connecting, keeping it", device.port_name);
-                        continue;
-                    },
-                    // Remove disconnected devices that are no longer present
-                    ConnectionState::Disconnected => {
-                        devices_to_remove.push(*device_id);
-                        log::info!("Marking disconnected device {} for removal (was physically disconnected)", device.port_name);
-                    },
-                    // Remove error state devices that are no longer present
-                    ConnectionState::Error(_) => {
-                        devices_to_remove.push(*device_id);
-                        log::info!("Marking error state device {} for removal (was physically disconnected)", device.port_name);
-                    },
-                }
-            }
-        }
-        
-        // Remove disconnected devices
-        for device_id in devices_to_remove.clone() {
-            devices_guard.remove(&device_id);
-            log::info!("Removed disconnected device: {:?}", device_id);
-        }
-
-        Ok(devices_to_remove)
-    }
+    // legacy cleanup_disconnected_devices removed: event-driven discovery now authoritative
 
     /// Get all known devices
     pub async fn get_devices(&self) -> Vec<Device> {
@@ -278,27 +263,26 @@ impl DeviceManager {
                         match protocol.get_device_status().await {
                             Ok(status) => {
                                 log::info!("Device status retrieved successfully: {:?}", status);
-                                // Update device with status info
+                                // Update device with status info first
                                 self.update_device_status(device_id, status).await;
-                                self.update_device_connection_state(device_id, ConnectionState::Connected).await;
-                                
-                                // Store connected device
+                                // Store connected device BEFORE emitting connected event to avoid race for frontend follow-up commands
+                                log::debug!("Storing connected device protocol before emitting Connected state");
                                 {
                                     let mut connected_guard = self.connected_device.lock().await;
                                     *connected_guard = Some((*device_id, protocol));
                                 }
                                 { let mut map = self.unified_handles.lock().await; map.insert(*device_id, handle.clone()); }
+                                // Now emit connected state
+                                log::debug!("Emitting Connected state after protocol stored");
+                                self.update_device_connection_state(device_id, ConnectionState::Connected).await;
 
-                                
                                 // Conditionally start monitoring based on display mode
                                 match crate::raw_state::DISPLAY_MODE {
                                     crate::raw_state::DisplayMode::HID => {
-                                        // Only start HID monitoring
                                         let _ = self.connect_hid().await;
                                         log::info!("Started HID monitoring (mode: HID)");
                                     },
                                     crate::raw_state::DisplayMode::Raw => {
-                                        // Start raw state monitoring if we have an app handle
                                         if let Some(app_handle) = &*self.app_handle.lock().await {
                                             let _ = self.start_raw_state_monitoring(app_handle.clone()).await;
                                             log::info!("Started raw state monitoring (mode: Raw)");
@@ -307,14 +291,13 @@ impl DeviceManager {
                                         }
                                     },
                                 }
-                                
                                 log::info!("Successfully connected to device: {}", device.port_name);
                                 Ok(())
                             }
                             Err(e) => {
                                 let error_msg = format!("Failed to get device status: {}", e);
                                 log::error!("{}", error_msg);
-                                self.update_device_connection_state(device_id, ConnectionState::Error(error_msg.clone())).await;
+                self.update_device_connection_state(device_id, ConnectionState::Error(error_msg.clone())).await;
                                 Err(DeviceError::SerialError(e))
                             }
                         }
@@ -322,7 +305,7 @@ impl DeviceManager {
                     Err(e) => {
                         let error_msg = format!("Protocol initialization failed: {}", e);
                         log::error!("{}", error_msg);
-                        self.update_device_connection_state(device_id, ConnectionState::Error(error_msg)).await;
+            self.update_device_connection_state(device_id, ConnectionState::Error(error_msg)).await;
                         Err(DeviceError::SerialError(e))
                     }
                 }
@@ -330,7 +313,7 @@ impl DeviceManager {
             Err(e) => {
                 let error_msg = format!("Connection failed: {}", e);
                 log::error!("{}", error_msg);
-                self.update_device_connection_state(device_id, ConnectionState::Error(error_msg)).await;
+        self.update_device_connection_state(device_id, ConnectionState::Error(error_msg)).await;
                 Err(DeviceError::SerialError(e))
             }
         }
@@ -338,22 +321,58 @@ impl DeviceManager {
 
     /// Disconnect from the currently connected device
     pub async fn disconnect_device(&self) -> Result<()> {
-        let mut connected_guard = self.connected_device.lock().await;
-        
-    {
-        if let Some((device_id, protocol)) = connected_guard.take() {
-            // Disconnect the serial interface
+        // First capture whether a device is connected (without taking ownership yet)
+        let device_id_opt = {
+            let connected_guard = self.connected_device.lock().await;
+            connected_guard.as_ref().map(|(id, _)| *id)
+        };
+
+        let device_id = match device_id_opt {
+            Some(id) => id,
+            None => return Err(DeviceError::NotConnected),
+        };
+
+        // Stop any active monitoring BEFORE tearing down protocol to avoid deadlocks on connected_device
+        match crate::raw_state::DISPLAY_MODE {
+            crate::raw_state::DisplayMode::Raw => {
+                if self.raw_monitoring_active.load(Ordering::Relaxed) {
+                    log::debug!("Stopping raw monitoring prior to disconnect for device {}", device_id);
+                    let _ = self.stop_raw_state_monitoring().await; // This acquires connected_device internally; safe because we are not holding it
+                }
+            },
+            crate::raw_state::DisplayMode::HID => {
+                // HID monitoring stop handled after protocol disconnect (does not lock connected_device)
+            },
+        }
+
+        // Now take ownership of the protocol and clear connected_device
+        let protocol_opt = {
+            let mut connected_guard = self.connected_device.lock().await;
+            connected_guard.take().map(|(_, protocol)| protocol)
+        };
+
+        if let Some(protocol) = protocol_opt {
+            // Perform protocol / serial disconnect
             protocol.disconnect_locked().await;
-            // Conditionally disconnect monitoring based on display mode
-            match crate::raw_state::DISPLAY_MODE {
-                crate::raw_state::DisplayMode::HID => { let _ = self.disconnect_hid().await; log::info!("Disconnected HID monitoring"); },
-                crate::raw_state::DisplayMode::Raw => { let _ = self.stop_raw_state_monitoring().await; log::info!("Stopped raw state monitoring"); },
-            }
-            self.update_device_connection_state(&device_id, ConnectionState::Disconnected).await;
-            log::info!("Disconnected from device");
-            return Ok(());
-        } else { return Err(DeviceError::NotConnected); }
-    }
+            log::debug!("Serial protocol disconnected for device {}", device_id);
+        }
+
+        // Remove unified handle (reader task will naturally terminate after port closed)
+        {
+            let mut handles = self.unified_handles.lock().await;
+            handles.remove(&device_id);
+        }
+
+        // Now handle HID monitoring stop (after protocol disconnect so underlying interface closed)
+        if matches!(crate::raw_state::DISPLAY_MODE, crate::raw_state::DisplayMode::HID) {
+            let _ = self.disconnect_hid().await; // Ignore errors (non-fatal)
+            log::info!("Disconnected HID monitoring");
+        }
+
+        // Emit disconnected state
+        self.update_device_connection_state(&device_id, ConnectionState::Disconnected).await;
+        log::info!("Disconnected from device {}", device_id);
+        Ok(())
     }
 
     /// Get the currently connected device ID
@@ -457,9 +476,29 @@ impl DeviceManager {
 
     /// Helper method to update device connection state
     async fn update_device_connection_state(&self, device_id: &Uuid, state: ConnectionState) {
+        // Normalize state for event emission
+        let (state_str, error_msg) = match &state {
+            ConnectionState::Connected => ("Connected", None),
+            ConnectionState::Connecting => ("Connecting", None),
+            ConnectionState::Disconnected => ("Disconnected", None),
+            ConnectionState::Error(msg) => ("Error", Some(msg.clone())),
+        };
         let mut devices_guard = self.devices.write().await;
         if let Some(device) = devices_guard.get_mut(device_id) {
             device.update_connection_state(state);
+        }
+        drop(devices_guard);
+        // Emit updated device list snapshot FIRST so frontend has current device object before connection event
+        self.emit_device_list().await; // internal logging added there
+        // Then emit standardized connection event payload
+        if let Some(app) = &*self.app_handle.lock().await {
+            let payload = if let Some(err) = error_msg { serde_json::json!({"id": device_id.to_string(), "state": state_str, "error": err}) } else { serde_json::json!({"id": device_id.to_string(), "state": state_str}) };
+            match app.emit("device_connection_changed", &payload) {
+                Ok(_) => log::info!("Emitted device_connection_changed: {} -> {}", device_id, state_str),
+                Err(e) => log::warn!("Failed to emit device_connection_changed ({}): {}", state_str, e),
+            }
+        } else {
+            log::debug!("Skipped device_connection_changed emission (app_handle not yet set) state={} id={}", state_str, device_id);
         }
     }
 
@@ -467,7 +506,29 @@ impl DeviceManager {
     async fn update_device_status(&self, device_id: &Uuid, status: crate::serial::protocol::DeviceStatus) {
         let mut devices_guard = self.devices.write().await;
         if let Some(device) = devices_guard.get_mut(device_id) {
-            device.update_device_status(status);
+            let mut sanitized = status.clone();
+            let original_fw = sanitized.firmware_version.clone();
+            let cleaned = Self::sanitize_firmware_version(&original_fw);
+            if cleaned != original_fw {
+                log::debug!("Sanitized firmware version '{}' -> '{}'", original_fw, cleaned);
+                sanitized.firmware_version = cleaned;
+            }
+            device.update_device_status(sanitized);
+        }
+        drop(devices_guard);
+        self.emit_device_list().await;
+    }
+
+    pub async fn emit_device_list(&self) {
+        if let Some(app) = &*self.app_handle.lock().await {
+            let list = self.get_devices().await;
+            let count = list.len();
+            match app.emit("device_list_updated", &list) {
+                Ok(_) => log::info!("Emitted device_list_updated ({} devices)", count),
+                Err(e) => log::warn!("Failed to emit device_list_updated: {}", e),
+            }
+        } else {
+            log::debug!("Skipped device_list_updated emission (app_handle not yet set)");
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,8 +19,8 @@ pub fn run() {
     .manage(device_manager)
     .invoke_handler(tauri::generate_handler![
       commands::discover_devices,
+  commands::force_discover_devices,
       commands::get_devices,
-      commands::cleanup_disconnected_devices,
       commands::connect_device,
       commands::disconnect_device,
       commands::get_connected_device,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,13 @@
 import { Dashboard } from '@/components/Dashboard'
 import { DeviceProvider } from '@/contexts/DeviceContext'
+import { RawStateConfigProvider } from '@/contexts/RawStateConfigContext'
 
 function App() {
   return (
     <DeviceProvider>
-      <Dashboard />
+      <RawStateConfigProvider>
+        <Dashboard />
+      </RawStateConfigProvider>
     </DeviceProvider>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,15 @@
 import { Dashboard } from '@/components/Dashboard'
 import { DeviceProvider } from '@/contexts/DeviceContext'
 import { RawStateConfigProvider } from '@/contexts/RawStateConfigContext'
+import { FirmwareUpdatesProvider } from '@/contexts/FirmwareUpdatesProvider'
 
 function App() {
   return (
     <DeviceProvider>
       <RawStateConfigProvider>
-        <Dashboard />
+        <FirmwareUpdatesProvider>
+          <Dashboard />
+        </FirmwareUpdatesProvider>
       </RawStateConfigProvider>
     </DeviceProvider>
   )

--- a/src/components/CollapsedSidebar.tsx
+++ b/src/components/CollapsedSidebar.tsx
@@ -7,7 +7,7 @@ import { Separator } from '@/components/ui/separator';
 
 import { useDeviceContext } from '@/contexts/DeviceContext';
 import { DeviceConfiguration } from './DeviceConfiguration';
-import { useFirmwareUpdates } from '@/hooks/useFirmwareUpdates';
+import { useFirmwareUpdatesContext } from '@/contexts/FirmwareUpdatesProvider';
 import type { Device, ParsedAxisConfig, ParsedButtonConfig, PinFunction } from '@/lib/types';
 
 interface DevicePinAssignments {
@@ -39,15 +39,7 @@ export function CollapsedSidebar({ onExpand, parsedAxes, parsedButtons, setParse
   const [connectingToId, setConnectingToId] = useState<string | null>(null);
 
   // Get current firmware version from connected device
-  const currentFirmwareVersion = connectedDevice?.device_status?.firmware_version;
-
-  // Use firmware update hook
-  const {
-    hasUpdateAvailable,
-  } = useFirmwareUpdates({
-    currentVersion: currentFirmwareVersion,
-    autoCheck: true,
-  });
+  const { hasUpdateAvailable } = useFirmwareUpdatesContext();
 
   const getDeviceStatusColor = (device: Device) => {
     if (device.connection_state === 'Connected') {

--- a/src/components/DeviceConfigManagement.tsx
+++ b/src/components/DeviceConfigManagement.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Download, Upload, RotateCcw, Trash2, HardDrive, FileText, AlertTriangle, TestTube } from 'lucide-react';
+import { Download, Upload, RotateCcw, Trash2, HardDrive, FileText, AlertTriangle, TestTube, CircuitBoard } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { useDeviceConfig } from '@/hooks/useDeviceConfig';
 import { useDeviceContext } from '@/contexts/DeviceContext';
@@ -17,6 +17,9 @@ import {
 } from '@/components/ui/dialog';
 import { toast } from 'sonner';
 import type { StorageInfo } from '@/lib/types';
+import { useRawStateConfig } from '@/contexts/RawStateConfigContext';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
 
 export function DeviceConfigManagement() {
   const { isConnected } = useDeviceContext();
@@ -35,6 +38,7 @@ export function DeviceConfigManagement() {
   const [files, setFiles] = useState<string[]>([]);
   const [showResetDialog, setShowResetDialog] = useState(false);
   const [showFormatDialog, setShowFormatDialog] = useState(false);
+  const { gpioPullMode, shiftRegPullMode, toggleGpioPullMode, toggleShiftRegPullMode } = useRawStateConfig();
 
   // Load storage info
   const loadStorageInfo = async () => {
@@ -220,6 +224,64 @@ export function DeviceConfigManagement() {
             <HardDrive className="mr-2 h-4 w-4" />
             Load Storage Info
           </Button>
+        </CardContent>
+      </Card>
+
+      {/* Raw State Interpretation Settings */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2"><CircuitBoard className="h-4 w-4" /> Raw State Interpretation</CardTitle>
+          <CardDescription>Configure how raw voltage levels map to logical ACTIVE state</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-6 md:grid-cols-2">
+            {/* GPIO Pull Mode */}
+            <div className="flex items-start gap-4 p-3 rounded border bg-muted/20">
+              <div className="flex-1 space-y-1">
+                <Label htmlFor="gpio-pull-mode" className="flex items-center gap-2">GPIO Pull Mode
+                  <span className="text-xs font-normal text-muted-foreground">({gpioPullMode})</span>
+                </Label>
+                <p className="text-xs text-muted-foreground select-none">
+                  Determines which physical level represents logical ACTIVE for GPIO pins.
+                  {gpioPullMode === 'pull-up' ? ' LOW→ACTIVE, HIGH→idle' : ' HIGH→ACTIVE, LOW→idle'}
+                </p>
+              </div>
+              <div className="flex flex-col items-end gap-1">
+                <Switch
+                  id="gpio-pull-mode"
+                  checked={gpioPullMode === 'pull-up'}
+                  onCheckedChange={toggleGpioPullMode}
+                  className="data-[state=checked]:bg-emerald-500 data-[state=unchecked]:bg-gray-400"
+                />
+                <span className="text-[10px] uppercase tracking-wide text-muted-foreground select-none ">{gpioPullMode === 'pull-up' ? 'Pull-Up' : 'Pull-Down'}</span>
+              </div>
+            </div>
+
+            {/* Shift Register Pull Mode */}
+            <div className="flex items-start gap-4 p-3 rounded border bg-muted/20">
+              <div className="flex-1 space-y-1">
+                <Label htmlFor="shift-pull-mode" className="flex items-center gap-2">Shift Register Mode
+                  <span className="text-xs font-normal text-muted-foreground">({shiftRegPullMode})</span>
+                </Label>
+                <p className="text-xs text-muted-foreground select-none">
+                  Maps 74HC165 bit values to logical state.
+                  {shiftRegPullMode === 'pull-up' ? ' 0→ACTIVE, 1→idle' : ' 1→ACTIVE, 0→idle'}
+                </p>
+              </div>
+              <div className="flex flex-col items-end gap-1">
+                <Switch
+                  id="shift-pull-mode"
+                  checked={shiftRegPullMode === 'pull-up'}
+                  onCheckedChange={toggleShiftRegPullMode}
+                  className="data-[state=checked]:bg-emerald-500 data-[state=unchecked]:bg-gray-400"
+                />
+                <span className="text-[10px] uppercase tracking-wide text-muted-foreground select-none">{shiftRegPullMode === 'pull-up' ? 'Pull-Up' : 'Pull-Down'}</span>
+              </div>
+            </div>
+          </div>
+          <div className="text-xs text-muted-foreground leading-relaxed select-none">
+            Changing these settings only affects how the frontend interprets displayed raw states. It does not reconfigure the device firmware electrical pull resistors.
+          </div>
         </CardContent>
       </Card>
 

--- a/src/components/DeviceConfiguration.tsx
+++ b/src/components/DeviceConfiguration.tsx
@@ -133,8 +133,25 @@ export function DeviceConfiguration({
     }
   };
 
-  if (!connectedDevice || !deviceStatus) {
+  if (!connectedDevice) {
     return null;
+  }
+  if (!deviceStatus) {
+    return (
+      <Card className="mt-3 animate-pulse">
+        <CardHeader>
+          <CardTitle className="flex items-center text-sm">
+            <Settings className="w-4 h-4 mr-2" />
+            <span className="truncate">Device Configuration</span>
+          </CardTitle>
+          <CardDescription className="text-xs">Loading device status...</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="h-4 bg-muted rounded mb-2" />
+          <div className="h-4 bg-muted rounded w-2/3" />
+        </CardContent>
+      </Card>
+    );
   }
 
   if (collapsed) {

--- a/src/components/DeviceList.tsx
+++ b/src/components/DeviceList.tsx
@@ -9,7 +9,7 @@ import { Separator } from '@/components/ui/separator';
 
 import { useDeviceContext } from '@/contexts/DeviceContext';
 import { DeviceConfiguration } from './DeviceConfiguration';
-import { useFirmwareUpdates } from '@/hooks/useFirmwareUpdates';
+import { useFirmwareUpdatesContext } from '@/contexts/FirmwareUpdatesProvider';
 import type { Device, ParsedAxisConfig, ParsedButtonConfig, PinFunction } from '@/lib/types';
 
 interface DevicePinAssignments {
@@ -45,17 +45,7 @@ export function DeviceList({ onCollapse, deviceCount, onRefresh, isLoading: isRe
   const [connectingToId, setConnectingToId] = useState<string | null>(null);
 
   // Get current firmware version from connected device
-  const currentFirmwareVersion = connectedDevice?.device_status?.firmware_version;
-
-  // Use firmware update hook
-  const {
-    isChecking: isCheckingUpdates,
-    hasUpdateAvailable,
-    latestVersion,
-  } = useFirmwareUpdates({
-    currentVersion: currentFirmwareVersion,
-    autoCheck: true,
-  });
+  const { isChecking: isCheckingUpdates, hasUpdateAvailable, latestVersion } = useFirmwareUpdatesContext();
 
   const handleConnect = async (deviceId: string) => {
     setConnectingToId(deviceId);
@@ -155,7 +145,7 @@ export function DeviceList({ onCollapse, deviceCount, onRefresh, isLoading: isRe
             <Badge variant="outline" className="ml-2">v0.1.0</Badge>
           </div>
         </CardHeader>
-        {isConnected && currentFirmwareVersion && (
+  {isConnected && connectedDevice?.device_status?.firmware_version && (
           <CardContent className="pt-0">
             <Button 
               variant="outline" 

--- a/src/components/RawStateBadge.tsx
+++ b/src/components/RawStateBadge.tsx
@@ -52,7 +52,7 @@ export function RawStateBadge({ mode, state, label, tooltip, className }: RawSta
       className={cn(
         "w-12 h-12 rounded flex items-center justify-center text-[12px] font-mono font-bold transition-colors duration-50 select-none",
         colorSchemes[mode][state],
-        isChanging && "ring-2 ring-yellow-400",
+        isChanging && "",
         className
       )}
       title={tooltip}

--- a/src/contexts/DeviceContext.tsx
+++ b/src/contexts/DeviceContext.tsx
@@ -12,6 +12,7 @@ interface DeviceContextType {
   
   // Actions
   discoverDevices: () => Promise<Device[]>;
+  // Deprecated no-op methods retained temporarily for backward compatibility
   refreshDevices: (withCleanup?: boolean) => Promise<Device[]>;
   refreshDevicesSilently: (withCleanup?: boolean) => Promise<Device[]>;
   connectDevice: (deviceId: string) => Promise<boolean>;

--- a/src/contexts/FirmwareUpdatesContext.ts
+++ b/src/contexts/FirmwareUpdatesContext.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+import type { FirmwareUpdatesContextValue } from './firmwareUpdatesTypes';
+
+export const FirmwareUpdatesContext = createContext<FirmwareUpdatesContextValue | undefined>(undefined);

--- a/src/contexts/FirmwareUpdatesContext.tsx
+++ b/src/contexts/FirmwareUpdatesContext.tsx
@@ -1,0 +1,3 @@
+// Duplicate legacy file replaced by dedicated Provider/Context split implementation.
+// Intentionally left blank to avoid duplicate symbol errors.
+export {}; 

--- a/src/contexts/FirmwareUpdatesProvider.tsx
+++ b/src/contexts/FirmwareUpdatesProvider.tsx
@@ -1,0 +1,37 @@
+import React, { useContext, useMemo } from 'react';
+import { useFirmwareUpdates } from '@/hooks/useFirmwareUpdates';
+import { useDeviceContext } from '@/contexts/DeviceContext';
+import type { FirmwareUpdatesContextValue } from './firmwareUpdatesTypes';
+import { FirmwareUpdatesContext } from './FirmwareUpdatesContext';
+
+
+export const FirmwareUpdatesProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { connectedDevice } = useDeviceContext();
+  const currentFirmwareVersion = connectedDevice?.device_status?.firmware_version;
+
+  const hook = useFirmwareUpdates({ currentVersion: currentFirmwareVersion, autoCheck: true });
+
+  const value: FirmwareUpdatesContextValue = useMemo(() => ({
+    isChecking: hook.isChecking,
+    hasUpdateAvailable: hook.hasUpdateAvailable,
+    latestVersion: hook.latestVersion,
+    error: hook.error,
+    checkForUpdates: hook.checkForUpdates,
+    resetUpdateState: hook.resetUpdateState,
+    currentVersion: currentFirmwareVersion,
+  }), [hook.isChecking, hook.hasUpdateAvailable, hook.latestVersion, hook.error, hook.checkForUpdates, hook.resetUpdateState, currentFirmwareVersion]);
+
+  return (
+    <FirmwareUpdatesContext.Provider value={value}>
+      {children}
+    </FirmwareUpdatesContext.Provider>
+  );
+};
+
+export function useFirmwareUpdatesContext(): FirmwareUpdatesContextValue {
+  const ctx = useContext(FirmwareUpdatesContext);
+  if (!ctx) {
+    throw new Error('useFirmwareUpdatesContext must be used within a FirmwareUpdatesProvider');
+  }
+  return ctx;
+}

--- a/src/contexts/RawStateConfigContext.tsx
+++ b/src/contexts/RawStateConfigContext.tsx
@@ -1,0 +1,89 @@
+import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
+
+export type PullMode = 'pull-up' | 'pull-down';
+
+interface RawStateConfigContextValue {
+  gpioPullMode: PullMode;
+  shiftRegPullMode: PullMode;
+  setGpioPullMode: (mode: PullMode) => void;
+  setShiftRegPullMode: (mode: PullMode) => void;
+  toggleGpioPullMode: () => void;
+  toggleShiftRegPullMode: () => void;
+}
+
+const RawStateConfigContext = createContext<RawStateConfigContextValue | undefined>(undefined);
+
+const LS_KEY = 'joycore.rawStateConfig.v1';
+
+interface PersistedState {
+  gpioPullMode: PullMode;
+  shiftRegPullMode: PullMode;
+}
+
+const defaultState: PersistedState = {
+  gpioPullMode: 'pull-down', // default typical for input with external pull-down
+  shiftRegPullMode: 'pull-down',
+};
+
+function loadState(): PersistedState {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    if (!raw) return defaultState;
+    const parsed = JSON.parse(raw) as Partial<PersistedState>;
+    return {
+      gpioPullMode: parsed.gpioPullMode === 'pull-up' ? 'pull-up' : 'pull-down',
+      shiftRegPullMode: parsed.shiftRegPullMode === 'pull-up' ? 'pull-up' : 'pull-down',
+    };
+  } catch {
+    return defaultState;
+  }
+}
+
+function saveState(state: PersistedState) {
+  try {
+    localStorage.setItem(LS_KEY, JSON.stringify(state));
+  } catch {
+    // ignore
+  }
+}
+
+export const RawStateConfigProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [gpioPullMode, setGpioPullModeState] = useState<PullMode>(defaultState.gpioPullMode);
+  const [shiftRegPullMode, setShiftRegPullModeState] = useState<PullMode>(defaultState.shiftRegPullMode);
+
+  // Load on mount
+  useEffect(() => {
+    const s = loadState();
+    setGpioPullModeState(s.gpioPullMode);
+    setShiftRegPullModeState(s.shiftRegPullMode);
+  }, []);
+
+  // Persist whenever changes
+  useEffect(() => {
+    saveState({ gpioPullMode, shiftRegPullMode });
+  }, [gpioPullMode, shiftRegPullMode]);
+
+  const setGpioPullMode = useCallback((mode: PullMode) => setGpioPullModeState(mode), []);
+  const setShiftRegPullMode = useCallback((mode: PullMode) => setShiftRegPullModeState(mode), []);
+  const toggleGpioPullMode = useCallback(() => setGpioPullModeState(m => (m === 'pull-up' ? 'pull-down' : 'pull-up')), []);
+  const toggleShiftRegPullMode = useCallback(() => setShiftRegPullModeState(m => (m === 'pull-up' ? 'pull-down' : 'pull-up')), []);
+
+  return (
+    <RawStateConfigContext.Provider value={{
+      gpioPullMode,
+      shiftRegPullMode,
+      setGpioPullMode,
+      setShiftRegPullMode,
+      toggleGpioPullMode,
+      toggleShiftRegPullMode,
+    }}>
+      {children}
+    </RawStateConfigContext.Provider>
+  );
+};
+
+export function useRawStateConfig() {
+  const ctx = useContext(RawStateConfigContext);
+  if (!ctx) throw new Error('useRawStateConfig must be used within RawStateConfigProvider');
+  return ctx;
+}

--- a/src/contexts/firmwareUpdatesTypes.ts
+++ b/src/contexts/firmwareUpdatesTypes.ts
@@ -1,0 +1,16 @@
+export interface VersionCheckResult {
+  current_version: string;
+  latest_version: string;
+  update_available: boolean;
+  release_info?: unknown;
+}
+
+export interface FirmwareUpdatesContextValue {
+  isChecking: boolean;
+  hasUpdateAvailable: boolean;
+  latestVersion?: string;
+  error: string | null;
+  checkForUpdates: (version?: string) => Promise<VersionCheckResult | null>;
+  resetUpdateState: () => void;
+  currentVersion?: string;
+}


### PR DESCRIPTION
This pull request introduces a major refactor to device management, moving from interval polling and manual cleanup to an event-driven architecture. The backend now emits authoritative device events, and the frontend subscribes to these, eliminating race conditions and improving reliability. Legacy cleanup and polling logic have been removed, and device identification is now stable, preventing UI flicker. Additional improvements include a new firmware version sanitizer and proper ordering of connection state updates.

**Event-Driven Device Management:**

* Replaced interval polling and manual cleanup with backend-emitted events (`device_list_updated`, `device_connection_changed`), and updated the frontend to subscribe to these events. Legacy polling and cleanup logic were removed. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52-R73) [[2]](diffhunk://#diff-70b532988e5ac55368778eadac154fffc366f4c1720abe5dfbc159e6a3e80b24L75-R193)
* Device IDs are now stable (`port_name:serial_number`), preventing UI remount flicker and UUID churn. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52-R73) [[2]](diffhunk://#diff-70b532988e5ac55368778eadac154fffc366f4c1720abe5dfbc159e6a3e80b24R27-R29)

**Backend API and Logic Changes:**

* Removed the legacy `cleanup_disconnected_devices` command and introduced `force_discover_devices`, which performs a bounded burst of discovery attempts for reliable hot-plug detection. [[1]](diffhunk://#diff-59f7096c7cd88d5d187e749ca400716cd225f951e78eac3d0081ec6c28ce5dccL35-R60) [[2]](diffhunk://#diff-70b532988e5ac55368778eadac154fffc366f4c1720abe5dfbc159e6a3e80b24L75-R193)
* Discovery logic now maintains a map of stable keys to device IDs, cleans up disconnected devices naturally, and emits device list updates after each discovery. [[1]](diffhunk://#diff-70b532988e5ac55368778eadac154fffc366f4c1720abe5dfbc159e6a3e80b24R27-R29) [[2]](diffhunk://#diff-70b532988e5ac55368778eadac154fffc366f4c1720abe5dfbc159e6a3e80b24L75-R193)

**Firmware Version Handling:**

* Added a new `sanitize_firmware_version` method to clean and normalize firmware version strings for better semver parsing and display.

**Connection State Management:**

* Ensured device protocol is stored before emitting connection events, preventing frontend race conditions when handling follow-up commands.

**Codebase Cleanup:**

* Removed all references to legacy cleanup and polling logic, simplifying the mental model and code paths for device management. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52-R73) [[2]](diffhunk://#diff-70b532988e5ac55368778eadac154fffc366f4c1720abe5dfbc159e6a3e80b24L75-R193)