### PR TITLE
Dev UI rework

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,32 +1,46 @@
+import * as React from 'react';
+import { Badge as UIBadge } from '@/components/ui/badge';
+import type { BadgeVariantProp } from '@/components/ui/badge-variants';
 import { cn } from '@/lib/utils';
-import React from 'react';
 
-export type BadgeVariant = 'yellow' | 'pink' | 'blue' | 'purple' | 'teal' | 'green' | 'red' | 'gray' |'success';
-export type BadgeSize = 'sm' | 'md' | 'lg';
+// Supported variants after legacy purge
+const variantMap: Record<string, BadgeVariantProp> = {
+  default: 'default',
+  primary: 'default', // still allow "primary"
+  secondary: 'secondary',
+  destructive: 'destructive',
+  success: 'success',
+  warning: 'warning',
+  info: 'info',
+  muted: 'muted',
+  brand1: 'brand1',
+  brand2: 'brand2',
+  brand3: 'brand3',
+  brand4: 'brand4',
+  brand5: 'brand5'
+};
 
-interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
-  variant?: BadgeVariant;
-  size?: BadgeSize;
-  inactive?: boolean;
-  pressed?: boolean;
-  children: React.ReactNode;
-  className?: string;
+export interface BadgeProps extends Omit<React.ComponentProps<typeof UIBadge>, 'variant'> {
+  variant?: keyof typeof variantMap;
+  size?: 'sm' | 'md' | 'lg';
 }
 
-export function Badge({ variant = 'gray', size = 'md', inactive, pressed, children, className, ...rest }: BadgeProps) {
+export function Badge({ variant = 'default', size = 'md', className, ...rest }: BadgeProps) {
+  const mapped: BadgeVariantProp = variantMap[variant] ?? 'default';
+  const sizeClasses =
+    size === 'sm'
+      ? 'h-5 px-1.5 text-[10px]'
+      : size === 'lg'
+      ? 'h-8 px-3 text-sm'
+      : 'h-6 px-2'; // md
+
   return (
-    <div
-      data-size={size}
-      className={cn(
-        'badge',
-        `badge-${variant}`,
-        inactive && 'badge-inactive',
-        pressed && 'badge-pressed',
-        className
-      )}
+    <UIBadge
+      variant={mapped}
+      className={cn(sizeClasses, className)}
       {...rest}
-    >
-      {children}
-    </div>
+    />
   );
 }
+
+export default Badge;

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,0 +1,32 @@
+import { cn } from '@/lib/utils';
+import React from 'react';
+
+export type BadgeVariant = 'yellow' | 'pink' | 'blue' | 'purple' | 'teal' | 'green' | 'red' | 'gray' |'success';
+export type BadgeSize = 'sm' | 'md' | 'lg';
+
+interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: BadgeVariant;
+  size?: BadgeSize;
+  inactive?: boolean;
+  pressed?: boolean;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Badge({ variant = 'gray', size = 'md', inactive, pressed, children, className, ...rest }: BadgeProps) {
+  return (
+    <div
+      data-size={size}
+      className={cn(
+        'badge',
+        `badge-${variant}`,
+        inactive && 'badge-inactive',
+        pressed && 'badge-pressed',
+        className
+      )}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/ButtonStateBadge.tsx
+++ b/src/components/ButtonStateBadge.tsx
@@ -1,4 +1,6 @@
 import { cn } from '@/lib/utils';
+import { Badge } from './Badge';
+import type { BadgeVariant } from './Badge';
 
 interface ButtonStateBadgeProps {
   label: string;
@@ -7,25 +9,31 @@ interface ButtonStateBadgeProps {
 }
 
 export function ButtonStateBadge({ label, state, className }: ButtonStateBadgeProps) {
+  const { variant, inactive, pressed } = ((): { variant: BadgeVariant; inactive?: boolean; pressed?: boolean } => {
+    switch (state) {
+      case 'unconfigured':
+        return { variant: 'gray', inactive: true };
+      case 'configured':
+        return { variant: 'blue' };
+      case 'pressed':
+        return { variant: 'red', pressed: true };
+      case 'pressed-unconfigured':
+        return { variant: 'red', inactive: true };
+      default:
+        return { variant: 'gray', inactive: true };
+    }
+  })();
+
   return (
-    <div   
-      className={cn(
-        "w-12 h-12 rounded flex items-center justify-center text-[12px] font-mono font-bold transition-colors duration-50 select-none",
-        {
-          // State 1: Gray/muted - Configured but no logical button assigned, not pressed
-          "bg-gray-600/10 text-gray-400/50 border border-gray-600/50": state === 'unconfigured',
-          // State 2: Blue/colored - Configured with logical button assigned, not pressed  
-          "bg-gray-600 text-white border border-gray-500": state === 'configured',
-          // State 3: Green/highlighted - Configured with logical button and currently pressed
-          "bg-red-500 text-white border border-red-400 shadow-lg shadow-red-500/50": state === 'pressed',
-          // State 4: Red/muted - Configured but no logical button assigned, currently pressed
-          "bg-red-500/50 text-red-300 border border-red-400/50": state === 'pressed-unconfigured',
-        },
-        className
-      )}
+    <Badge
+      size="md"
+  variant={variant}
+      inactive={inactive}
+      pressed={pressed}
+      className={cn(className)}
       title={label}
     >
       {label.replace(/[^0-9]/g, '') || '?'}
-    </div>
+    </Badge>
   );
 }

--- a/src/components/DeviceList.tsx
+++ b/src/components/DeviceList.tsx
@@ -157,7 +157,7 @@ export function DeviceList({ onCollapse, deviceCount, onRefresh, isLoading: isRe
               <Download className={`w-4 h-4 mr-2 ${isCheckingUpdates ? 'animate-pulse' : ''}`} />
               {hasUpdateAvailable ? 'Update Available' : 'Check Updates'}
               {hasUpdateAvailable && (
-                <Badge variant="yellow" className="ml-2">
+                <Badge variant="brand4" className="ml-2">
                   {latestVersion}
                 </Badge>
               )}

--- a/src/components/PicoSVG.tsx
+++ b/src/components/PicoSVG.tsx
@@ -102,11 +102,11 @@ export function PicoSVG({ pinConfigurations, onPinFunctionChange }: PicoSVGProps
                       size="xs"
                     />
                     {pinConfig.gpioNumber !== undefined && (
-                      <Badge variant="blue" className="font-mono min-w-[2.5rem] text-center">
+                      <Badge variant="teal" className="font-mono min-w-[2.5rem] text-center">
                         GP{pinConfig.gpioNumber}
                       </Badge>
                     )}
-                    <Badge variant="info" className="font-mono min-w-[2rem] text-center">
+                    <Badge variant="green" className="font-mono min-w-[2rem] text-center">
                       {pin}
                     </Badge>
                   </>
@@ -138,11 +138,11 @@ export function PicoSVG({ pinConfigurations, onPinFunctionChange }: PicoSVGProps
               <div className="flex items-center space-x-2">
                 {isConfigurable ? (
                   <>
-                    <Badge variant="info" className="font-mono min-w-[2rem] text-center">
+                    <Badge variant="green" className="font-mono min-w-[2rem] text-center">
                       {pin}
                     </Badge>
                     {pinConfig.gpioNumber !== undefined && (
-                      <Badge variant="blue" className="font-mono min-w-[2.5rem] text-center">
+                      <Badge variant="teal" className="font-mono min-w-[2.5rem] text-center">
                         GP{pinConfig.gpioNumber}
                       </Badge>
                     )}

--- a/src/components/PicoSVG.tsx
+++ b/src/components/PicoSVG.tsx
@@ -102,11 +102,11 @@ export function PicoSVG({ pinConfigurations, onPinFunctionChange }: PicoSVGProps
                       size="xs"
                     />
                     {pinConfig.gpioNumber !== undefined && (
-                      <Badge variant="teal" className="font-mono min-w-[2.5rem] text-center">
+                      <Badge variant="brand3" className="font-mono min-w-[2.5rem] text-center">
                         GP{pinConfig.gpioNumber}
                       </Badge>
                     )}
-                    <Badge variant="green" className="font-mono min-w-[2rem] text-center">
+                    <Badge variant="success" className="font-mono min-w-[2rem] text-center">
                       {pin}
                     </Badge>
                   </>
@@ -138,11 +138,11 @@ export function PicoSVG({ pinConfigurations, onPinFunctionChange }: PicoSVGProps
               <div className="flex items-center space-x-2">
                 {isConfigurable ? (
                   <>
-                    <Badge variant="green" className="font-mono min-w-[2rem] text-center">
+                    <Badge variant="success" className="font-mono min-w-[2rem] text-center">
                       {pin}
                     </Badge>
                     {pinConfig.gpioNumber !== undefined && (
-                      <Badge variant="teal" className="font-mono min-w-[2.5rem] text-center">
+                      <Badge variant="brand3" className="font-mono min-w-[2.5rem] text-center">
                         GP{pinConfig.gpioNumber}
                       </Badge>
                     )}

--- a/src/components/PinDropdown.tsx
+++ b/src/components/PinDropdown.tsx
@@ -6,7 +6,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Badge } from '@/components/ui/badge';
 import type { PinFunction, PinConfiguration } from '@/lib/types';
 
 interface PinDropdownProps {
@@ -20,9 +19,7 @@ export function PinDropdown({ pinConfig, onFunctionChange, size = 'xs' }: PinDro
 
   if (!isConfigurable) {
     return (
-      <Badge variant="secondary" className="font-mono">
-        {pinConfig.defaultLabel}
-      </Badge>
+      <span className="pin-func-item pin-func-gray w-24 text-center">{pinConfig.defaultLabel}</span>
     );
   }
 
@@ -117,35 +114,44 @@ export function PinDropdown({ pinConfig, onFunctionChange, size = 'xs' }: PinDro
     }
   };
 
-  const getFunctionBadgeVariant = (func: PinFunction): "default" | "secondary" | "destructive" | "outline" | "success" | "warning" | "info" | "yellow" | "pink" | "blue" | "purple" | "teal" => {
-    if (func === 'PIN_UNUSED') return 'secondary';
+  const getFunctionVariant = (func: PinFunction): string => {
+    if (func === 'PIN_UNUSED') return 'gray';
     if (func.startsWith('BTN')) return 'blue';
     if (func.startsWith('SHIFTREG')) return 'purple';
     if (func === 'ANALOG_AXIS') return 'teal';
-    if (func.startsWith('SPI')) return 'outline';
-    if (func.startsWith('I2C')) return 'destructive';
+    if (func.startsWith('SPI')) return 'yellow';
+    if (func.startsWith('I2C')) return 'red';
     if (func.startsWith('UART')) return 'yellow';
     if (func.startsWith('PWM')) return 'pink';
-    return 'default';
+    return 'gray';
   };
 
   return (
     <Select value={currentFunction} onValueChange={handleValueChange}>
-      <SelectTrigger size={size} className="w-36">
-        <SelectValue>
-          <Badge variant={getFunctionBadgeVariant(currentFunction)} className="font-mono text-xs">
-            {getFunctionDisplayName(currentFunction)}
-          </Badge>
-        </SelectValue>
-      </SelectTrigger>
+      {(() => {
+        const triggerVariant = getFunctionVariant(currentFunction);
+        return (
+          <SelectTrigger
+            size={size}
+            className={`w-36 pin-func-${triggerVariant} font-mono font-semibold text-xs border-transparent focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-offset-0`}
+          >
+            <SelectValue>{getFunctionDisplayName(currentFunction)}</SelectValue>
+          </SelectTrigger>
+        );
+      })()}
       <SelectContent>
-        {availableFunctions.map((func) => (
-          <SelectItem key={func} value={func}>
-            <Badge variant={getFunctionBadgeVariant(func)} className="font-mono text-xs">
+        {availableFunctions.map((func) => {
+          const variant = getFunctionVariant(func);
+          return (
+            <SelectItem
+              key={func}
+              value={func}
+              className={`pin-func-item pin-func-${variant}`}
+            >
               {getFunctionDisplayName(func)}
-            </Badge>
-          </SelectItem>
-        ))}
+            </SelectItem>
+          );
+        })}
       </SelectContent>
     </Select>
   );

--- a/src/components/PinDropdown.tsx
+++ b/src/components/PinDropdown.tsx
@@ -7,6 +7,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import type { PinFunction, PinConfiguration } from '@/lib/types';
+import { cn } from '@/lib/utils';
 
 interface PinDropdownProps {
   pinConfig: PinConfiguration;
@@ -14,12 +15,25 @@ interface PinDropdownProps {
   size?: 'xs' | 'default';
 }
 
+// Map pin function categories to brand/status color utility classes
+function functionColor(func: PinFunction): string {
+  if (func === 'PIN_UNUSED') return 'bg-muted text-muted-foreground';
+  if (func.startsWith('BTN')) return 'bg-brand-1 text-brand-1-foreground';
+  if (func.startsWith('SHIFTREG')) return 'bg-brand-2 text-brand-2-foreground';
+  if (func === 'ANALOG_AXIS') return 'bg-brand-3 text-brand-3-foreground';
+  if (func.startsWith('SPI')) return 'bg-brand-4 text-brand-4-foreground';
+  if (func.startsWith('I2C')) return 'bg-destructive text-destructive-foreground';
+  if (func.startsWith('UART')) return 'bg-brand-4 text-brand-4-foreground';
+  if (func.startsWith('PWM')) return 'bg-brand-5 text-brand-5-foreground';
+  return 'bg-muted text-muted-foreground';
+}
+
 export function PinDropdown({ pinConfig, onFunctionChange, size = 'xs' }: PinDropdownProps) {
   const { pinNumber, currentFunction, availableFunctions, isConfigurable } = pinConfig;
 
   if (!isConfigurable) {
     return (
-      <span className="pin-func-item pin-func-gray w-24 text-center">{pinConfig.defaultLabel}</span>
+      <span className={cn('w-24 text-center rounded-sm px-2 py-1.5 text-xs font-mono font-semibold', functionColor('PIN_UNUSED'))}>{pinConfig.defaultLabel}</span>
     );
   }
 
@@ -114,26 +128,14 @@ export function PinDropdown({ pinConfig, onFunctionChange, size = 'xs' }: PinDro
     }
   };
 
-  const getFunctionVariant = (func: PinFunction): string => {
-    if (func === 'PIN_UNUSED') return 'gray';
-    if (func.startsWith('BTN')) return 'blue';
-    if (func.startsWith('SHIFTREG')) return 'purple';
-    if (func === 'ANALOG_AXIS') return 'teal';
-    if (func.startsWith('SPI')) return 'yellow';
-    if (func.startsWith('I2C')) return 'red';
-    if (func.startsWith('UART')) return 'yellow';
-    if (func.startsWith('PWM')) return 'pink';
-    return 'gray';
-  };
-
   return (
     <Select value={currentFunction} onValueChange={handleValueChange}>
       {(() => {
-        const triggerVariant = getFunctionVariant(currentFunction);
+        const triggerClasses = functionColor(currentFunction);
         return (
           <SelectTrigger
             size={size}
-            className={`w-36 pin-func-${triggerVariant} font-mono font-semibold text-xs border-transparent focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-offset-0`}
+            className={cn('w-36 font-mono font-semibold text-xs border-transparent focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-offset-0', triggerClasses)}
           >
             <SelectValue>{getFunctionDisplayName(currentFunction)}</SelectValue>
           </SelectTrigger>
@@ -141,12 +143,12 @@ export function PinDropdown({ pinConfig, onFunctionChange, size = 'xs' }: PinDro
       })()}
       <SelectContent>
         {availableFunctions.map((func) => {
-          const variant = getFunctionVariant(func);
+          const itemClasses = functionColor(func);
           return (
             <SelectItem
               key={func}
               value={func}
-              className={`pin-func-item pin-func-${variant}`}
+              className={cn('rounded-sm px-2 py-1.5 text-xs font-mono font-semibold flex items-center gap-2 cursor-pointer select-none', itemClasses)}
             >
               {getFunctionDisplayName(func)}
             </SelectItem>

--- a/src/components/PinoutConfiguration.tsx
+++ b/src/components/PinoutConfiguration.tsx
@@ -237,9 +237,9 @@ export function PinoutConfiguration({ devicePinAssignments }: PinoutConfiguratio
               <div className="space-y-2">
                 <Badge variant="yellow" className="font-semibold">Communication</Badge>
                 <div className="space-y-1 text-xs">
-                  <div><Badge variant="secondary" className="mr-2">SPI</Badge>Serial Peripheral Interface</div>
-                  <div><Badge variant="destructive" className="mr-2">I2C</Badge>Inter-Integrated Circuit</div>
-                  <div><Badge variant="warning" className="mr-2">UART</Badge>Serial communication</div>
+                  <div><Badge variant="yellow" className="mr-2">SPI</Badge>Serial Peripheral Interface</div>
+                  <div><Badge variant="red" className="mr-2">I2C</Badge>Inter-Integrated Circuit</div>
+                  <div><Badge variant="yellow" className="mr-2">UART</Badge>Serial communication</div>
                   <div><Badge variant="pink" className="mr-2">PWM</Badge>Pulse Width Modulation</div>
                 </div>
               </div>

--- a/src/components/PinoutConfiguration.tsx
+++ b/src/components/PinoutConfiguration.tsx
@@ -213,7 +213,7 @@ export function PinoutConfiguration({ devicePinAssignments }: PinoutConfiguratio
           <CardContent>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
               <div className="space-y-2">
-                <Badge variant="blue" className="font-semibold">Button Functions</Badge>
+                <Badge variant="brand1" className="font-semibold">Button Functions</Badge>
                 <div className="space-y-1 text-xs">
                   <div>BTN - Single button input</div>
                   <div>BTN_ROW - Button matrix row</div>
@@ -221,7 +221,7 @@ export function PinoutConfiguration({ devicePinAssignments }: PinoutConfiguratio
                 </div>
               </div>
               <div className="space-y-2">
-                <Badge variant="purple" className="font-semibold">Shift Register</Badge>
+                <Badge variant="brand2" className="font-semibold">Shift Register</Badge>
                 <div className="space-y-1 text-xs">
                   <div>SHIFTREG_PL - Parallel load</div>
                   <div>SHIFTREG_CLK - Clock</div>
@@ -229,18 +229,18 @@ export function PinoutConfiguration({ devicePinAssignments }: PinoutConfiguratio
                 </div>
               </div>
               <div className="space-y-2">
-                <Badge variant="teal" className="font-semibold">Analog</Badge>
+                <Badge variant="brand3" className="font-semibold">Analog</Badge>
                 <div className="space-y-1 text-xs">
                   <div>ANALOG_AXIS - Analog axis input</div>
                 </div>
               </div>
               <div className="space-y-2">
-                <Badge variant="yellow" className="font-semibold">Communication</Badge>
+                <Badge variant="brand4" className="font-semibold">Communication</Badge>
                 <div className="space-y-1 text-xs">
-                  <div><Badge variant="yellow" className="mr-2">SPI</Badge>Serial Peripheral Interface</div>
-                  <div><Badge variant="red" className="mr-2">I2C</Badge>Inter-Integrated Circuit</div>
-                  <div><Badge variant="yellow" className="mr-2">UART</Badge>Serial communication</div>
-                  <div><Badge variant="pink" className="mr-2">PWM</Badge>Pulse Width Modulation</div>
+                  <div><Badge variant="brand4" className="mr-2">SPI</Badge>Serial Peripheral Interface</div>
+                  <div><Badge variant="destructive" className="mr-2">I2C</Badge>Inter-Integrated Circuit</div>
+                  <div><Badge variant="brand4" className="mr-2">UART</Badge>Serial communication</div>
+                  <div><Badge variant="brand5" className="mr-2">PWM</Badge>Pulse Width Modulation</div>
                 </div>
               </div>
             </div>

--- a/src/components/RawPinStateBadge.tsx
+++ b/src/components/RawPinStateBadge.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { cn } from '@/lib/utils';
+import { Badge } from './Badge';
 import { RAW_STATE_CONFIG } from '@/lib/dev-config';
 import { useRawStateConfig } from '@/contexts/RawStateConfigContext';
 
@@ -45,18 +46,11 @@ export function RawPinStateBadge({
   const logicalActive = gpioPullMode === 'pull-up' ? !state : state;
 
   return (
-    <div 
-      className={cn(
-        "raw-pin-badge",
-        "px-3 py-2 rounded-md text-sm font-medium",
-        "transition-all duration-200 min-w-[80px] text-center",
-        "border shadow-sm",
-        logicalActive 
-          ? "bg-green-500 text-white border-green-600" 
-          : "bg-gray-200 text-gray-700 border-gray-300",
-        isChanging && "ring-2 ring-yellow-400 animate-pulse scale-105",
-        className
-      )}
+    <Badge
+      size="lg"
+      variant={logicalActive ? 'green' : 'gray'}
+      inactive={!logicalActive}
+      className={cn('raw-pin-badge min-w-[80px] shadow-sm', isChanging && 'ring-2 ring-badge-yellow animate-pulse scale-105', className)}
       title={`GPIO ${gpio}: Physical ${state ? 'HIGH (3.3V)' : 'LOW (0V)'} | Logical ${logicalActive ? 'ACTIVE' : 'inactive'} (${gpioPullMode})`}
     >
       <div className="flex flex-col items-center gap-1">
@@ -82,7 +76,7 @@ export function RawPinStateBadge({
           )}
         </div>
       </div>
-    </div>
+    </Badge>
   );
 }
 

--- a/src/components/RawPinStateBadge.tsx
+++ b/src/components/RawPinStateBadge.tsx
@@ -14,7 +14,7 @@ interface RawPinStateBadgeProps {
 
 /**
  * Visual indicator for raw GPIO pin state
- * Shows HIGH (3.3V) in green, LOW (0V) in gray
+ * Shows HIGH (3.3V) in success (green), LOW (0V) in muted/gray
  * Includes change highlighting animation
  */
 export function RawPinStateBadge({ 
@@ -48,9 +48,12 @@ export function RawPinStateBadge({
   return (
     <Badge
       size="lg"
-      variant={logicalActive ? 'green' : 'gray'}
-      inactive={!logicalActive}
-      className={cn('raw-pin-badge min-w-[80px] shadow-sm', isChanging && 'ring-2 ring-badge-yellow animate-pulse scale-105', className)}
+      variant={logicalActive ? 'success' : 'gray'}
+      className={cn(
+        'raw-pin-badge min-w-[80px] shadow-sm transition-transform',
+        isChanging && 'ring-2 ring-brand-4/70 animate-pulse scale-105',
+        className
+      )}
       title={`GPIO ${gpio}: Physical ${state ? 'HIGH (3.3V)' : 'LOW (0V)'} | Logical ${logicalActive ? 'ACTIVE' : 'inactive'} (${gpioPullMode})`}
     >
       <div className="flex flex-col items-center gap-1">

--- a/src/components/RawStateBadge.tsx
+++ b/src/components/RawStateBadge.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { cn } from '@/lib/utils';
+import { Badge } from './Badge';
+import type { BadgeVariant } from './Badge';
 import { RAW_STATE_CONFIG } from '@/lib/dev-config';
 import { useRawStateConfig } from '@/contexts/RawStateConfigContext';
 
@@ -31,34 +33,30 @@ export function RawStateBadge({ mode, state, label, tooltip, className }: RawSta
     }
   }, [state]);
 
-  // Color schemes for different modes
-  const colorSchemes = {
-    gpio: {
-      active: "bg-green-500 text-white border border-green-400",
-      inactive: "bg-gray-600 text-white border border-gray-500"
-    },
-    matrix: {
-      active: "bg-green-500 text-white border border-green-400",
-      inactive: "bg-gray-600 text-white border border-gray-500"
-    },
-    shiftreg: {
-      active: "bg-blue-500 text-white border border-blue-400",
-      inactive: "bg-gray-600 text-white border border-gray-500"
+  // Map mode/state to variants
+  const resolveVariant = (): { variant: BadgeVariant; inactive?: boolean } => {
+    const activeVariant: Record<RawStateBadgeMode, BadgeVariant> = {
+      gpio: 'green',
+      matrix: 'green',
+      shiftreg: 'blue'
+    };
+    if (state === 'inactive') {
+      return { variant: 'gray', inactive: true };
     }
+    return { variant: activeVariant[mode] };
   };
+  const { variant, inactive } = resolveVariant();
 
   return (
-    <div
-      className={cn(
-        "w-12 h-12 rounded flex items-center justify-center text-[12px] font-mono font-bold transition-colors duration-50 select-none",
-        colorSchemes[mode][state],
-        isChanging && "",
-        className
-      )}
+    <Badge
+      size="md"
+      variant={variant}
+      inactive={inactive}
+      className={cn(isChanging && '', className)}
       title={tooltip}
     >
       {label}
-    </div>
+    </Badge>
   );
 }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -228,7 +228,7 @@ export function Sidebar({ collapsed, onRefresh, isRefreshing, parsedAxes, parsed
               <>
                 {hasUpdateAvailable ? 'Update Available' : 'Check Updates'}
                 {hasUpdateAvailable && (
-                  <Badge variant="yellow" className="ml-2">{latestVersion}</Badge>
+                  <Badge variant="brand4" className="ml-2">{latestVersion}</Badge>
                 )}
               </>
             )}

--- a/src/components/ui/badge-variants.ts
+++ b/src/components/ui/badge-variants.ts
@@ -1,0 +1,29 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+export const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded border px-2 py-0.5 text-xs font-semibold w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden select-none",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary: "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive: "border-transparent bg-destructive text-destructive-foreground [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
+        outline: "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        success: "border-transparent bg-success text-success-foreground [a&]:hover:bg-success/90",
+        warning: "border-transparent bg-warning text-warning-foreground [a&]:hover:bg-warning/90",
+        info: "border-transparent bg-info text-info-foreground [a&]:hover:bg-info/90",
+        muted: "border-transparent bg-muted text-muted-foreground [a&]:hover:bg-muted/90",
+        brand1: "border-transparent bg-brand-1 text-brand-1-foreground [a&]:hover:bg-brand-1/90",
+        brand2: "border-transparent bg-brand-2 text-brand-2-foreground [a&]:hover:bg-brand-2/90",
+        brand3: "border-transparent bg-brand-3 text-brand-3-foreground [a&]:hover:bg-brand-3/90",
+        brand4: "border-transparent bg-brand-4 text-brand-4-foreground [a&]:hover:bg-brand-4/90",
+        brand5: "border-transparent bg-brand-5 text-brand-5-foreground [a&]:hover:bg-brand-5/90",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export type BadgeVariantProp = NonNullable<VariantProps<typeof badgeVariants>["variant"]>;

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,51 +1,9 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import type { VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
-
-const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded border px-2 py-0.5 text-xs font-semibold w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden select-none",
-  {
-    variants: {
-      variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
-        secondary:
-          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
-        destructive:
-          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
-        outline:
-          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
-        success:
-          "border-transparent bg-success text-success-foreground [a&]:hover:bg-success/90",
-        warning:
-          "border-transparent bg-warning text-warning-foreground [a&]:hover:bg-warning/90",
-        info:
-          "border-transparent bg-info text-info-foreground [a&]:hover:bg-info/90",
-        yellow:
-          "border-transparent bg-badge-yellow text-badge-yellow-foreground [a&]:hover:bg-badge-yellow/90",
-        pink:
-          "border-transparent bg-badge-pink text-badge-pink-foreground [a&]:hover:bg-badge-pink/90",
-        blue:
-          "border-transparent bg-badge-blue text-badge-blue-foreground [a&]:hover:bg-badge-blue/90",
-        purple:
-          "border-transparent bg-badge-purple text-badge-purple-foreground [a&]:hover:bg-badge-purple/90",
-        teal:
-          "border-transparent bg-badge-teal text-badge-teal-foreground [a&]:hover:bg-badge-teal/90",
-        green:
-          "border-transparent bg-badge-green text-badge-green-foreground [a&]:hover:bg-badge-green/90",
-        red:
-          "border-transparent bg-badge-red text-badge-red-foreground [a&]:hover:bg-badge-red/90",
-        gray:
-          "border-transparent bg-badge-gray text-badge-gray-foreground [a&]:hover:bg-badge-gray/90",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-    },
-  }
-)
+import { badgeVariants } from "./badge-variants"
 
 function Badge({
   className,

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -33,6 +33,12 @@ const badgeVariants = cva(
           "border-transparent bg-badge-purple text-badge-purple-foreground [a&]:hover:bg-badge-purple/90",
         teal:
           "border-transparent bg-badge-teal text-badge-teal-foreground [a&]:hover:bg-badge-teal/90",
+        green:
+          "border-transparent bg-badge-green text-badge-green-foreground [a&]:hover:bg-badge-green/90",
+        red:
+          "border-transparent bg-badge-red text-badge-red-foreground [a&]:hover:bg-badge-red/90",
+        gray:
+          "border-transparent bg-badge-gray text-badge-gray-foreground [a&]:hover:bg-badge-gray/90",
       },
     },
     defaultVariants: {

--- a/src/components/ui/number-input.tsx
+++ b/src/components/ui/number-input.tsx
@@ -14,8 +14,9 @@ const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
   ({ className, value, onChange, min, max, step = 1, disabled, ...props }, ref) => {
     const [internalValue, setInternalValue] = React.useState(value ?? 0)
     const [isHolding, setIsHolding] = React.useState<'increment' | 'decrement' | null>(null)
-    const holdIntervalRef = React.useRef<NodeJS.Timeout>()
-    const holdTimeoutRef = React.useRef<NodeJS.Timeout>()
+  // Refs need explicit initial value for strict TS; allow null until timers created
+  const holdIntervalRef = React.useRef<NodeJS.Timeout | null>(null)
+  const holdTimeoutRef = React.useRef<NodeJS.Timeout | null>(null)
 
     // Use internal value if no value prop provided (uncontrolled mode)
     const currentValue = value !== undefined ? value : internalValue
@@ -54,15 +55,15 @@ const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
 
     const stopHold = () => {
       setIsHolding(null)
-      if (holdTimeoutRef.current) clearTimeout(holdTimeoutRef.current)
-      if (holdIntervalRef.current) clearInterval(holdIntervalRef.current)
+  if (holdTimeoutRef.current) clearTimeout(holdTimeoutRef.current)
+  if (holdIntervalRef.current) clearInterval(holdIntervalRef.current)
     }
 
     // Clean up on unmount
     React.useEffect(() => {
       return () => {
-        if (holdTimeoutRef.current) clearTimeout(holdTimeoutRef.current)
-        if (holdIntervalRef.current) clearInterval(holdIntervalRef.current)
+  if (holdTimeoutRef.current) clearTimeout(holdTimeoutRef.current)
+  if (holdIntervalRef.current) clearInterval(holdIntervalRef.current)
       }
     }, [])
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -110,7 +110,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+  "[&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -55,6 +55,12 @@
   --color-badge-purple-foreground: var(--badge-purple-foreground);
   --color-badge-teal: var(--badge-teal);
   --color-badge-teal-foreground: var(--badge-teal-foreground);
+  --color-badge-green: var(--badge-green);
+  --color-badge-green-foreground: var(--badge-green-foreground);
+  --color-badge-red: var(--badge-red);
+  --color-badge-red-foreground: var(--badge-red-foreground);
+  --color-badge-gray: var(--badge-gray);
+  --color-badge-gray-foreground: var(--badge-gray-foreground);
 }
 
 :root {
@@ -110,6 +116,13 @@
   --badge-purple-foreground: oklch(0.985 0 0);
   --badge-teal: oklch(0.696 0.17 162.48);
   --badge-teal-foreground: oklch(0.985 0 0);
+  /* Extended derived variants */
+  --badge-green: var(--success);
+  --badge-green-foreground: var(--success-foreground);
+  --badge-red: var(--destructive);
+  --badge-red-foreground: oklch(0.985 0 0);
+  --badge-gray: var(--muted);
+  --badge-gray-foreground: var(--muted-foreground);
 }
 
 .dark {
@@ -155,7 +168,7 @@
   
   /* Badge Color Variants */
   --badge-yellow: oklch(0.771 0.199 85.595);
-  --badge-yellow-foreground: oklch(0.145 0 0);
+  --badge-yellow-foreground: oklch(0.985 0 0);
   --badge-pink: oklch(0.647 0.281 10.217);
   --badge-pink-foreground: oklch(0.985 0 0);
   --badge-blue: oklch(0.618 0.193 231.029);
@@ -164,6 +177,12 @@
   --badge-purple-foreground: oklch(0.985 0 0);
   --badge-teal: oklch(0.696 0.17 162.48);
   --badge-teal-foreground: oklch(0.985 0 0);
+  --badge-green: var(--success);
+  --badge-green-foreground: var(--success-foreground);
+  --badge-red: var(--destructive);
+  --badge-red-foreground: oklch(0.985 0 0);
+  --badge-gray: var(--muted);
+  --badge-gray-foreground: var(--muted-foreground);
 }
 
 @layer base {
@@ -239,4 +258,86 @@
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 150ms;
   }
+  /* Unified Badge System */
+  .badge { @apply rounded font-mono font-bold select-none border text-[12px] flex items-center justify-center transition-colors duration-150; line-height:1; }
+  .badge[data-size="sm"] { @apply px-1.5 py-1 text-[10px]; }
+  .badge[data-size="md"] { @apply w-12 h-12; }
+  .badge[data-size="lg"] { @apply px-3 py-2 text-sm; }
+  .badge-yellow { background: var(--badge-yellow); color: var(--badge-yellow-foreground); border-color: color-mix(in oklab, var(--badge-yellow) 60%, black); }
+  .badge-pink { background: var(--badge-pink); color: var(--badge-pink-foreground); border-color: color-mix(in oklab, var(--badge-pink) 60%, black); }
+  .badge-blue { background: var(--badge-blue); color: var(--badge-blue-foreground); border-color: color-mix(in oklab, var(--badge-blue) 60%, black); }
+  .badge-purple { background: var(--badge-purple); color: var(--badge-purple-foreground); border-color: color-mix(in oklab, var(--badge-purple) 60%, black); }
+  .badge-teal { background: var(--badge-teal); color: var(--badge-teal-foreground); border-color: color-mix(in oklab, var(--badge-teal) 60%, black); }
+  .badge-green { background: var(--badge-green); color: var(--badge-green-foreground); border-color: color-mix(in oklab, var(--badge-green) 60%, black); }
+  .badge-red { background: var(--badge-red); color: var(--badge-red-foreground); border-color: color-mix(in oklab, var(--badge-red) 60%, black); }
+  .badge-gray { background: var(--badge-gray); color: var(--badge-gray-foreground); border-color: color-mix(in oklab, var(--badge-gray) 60%, black); }
+  .badge-inactive { opacity: .6; }
+  .badge-pressed { box-shadow: 0 0 0 2px color-mix(in oklab, var(--badge-red) 60%, transparent), 0 0 0 4px color-mix(in oklab, var(--badge-red) 30%, transparent); }
+  
+  /* Pin Function Dropdown Full-Row Variants */
+  .pin-func-item { @apply w-full rounded-sm px-2 py-1.5 text-xs font-mono font-semibold flex items-center gap-2 transition-colors cursor-pointer select-none; }
+  .pin-func-blue { background: var(--badge-blue); color: var(--badge-blue-foreground); }
+  .pin-func-purple { background: var(--badge-purple); color: var(--badge-purple-foreground); }
+  .pin-func-teal { background: var(--badge-teal); color: var(--badge-teal-foreground); }
+  .pin-func-yellow { background: var(--badge-yellow); color: var(--badge-yellow-foreground); }
+  .pin-func-red { background: var(--badge-red); color: var(--badge-red-foreground); }
+  .pin-func-pink { background: var(--badge-pink); color: var(--badge-pink-foreground); }
+  .pin-func-green { background: var(--badge-green); color: var(--badge-green-foreground); }
+  .pin-func-gray { background: var(--badge-gray); color: var(--badge-gray-foreground); }
+  /* Ensure trigger gets full background when variant class applied */
+  [data-slot='select-trigger'].pin-func-blue { background: var(--badge-blue) !important; color: var(--badge-blue-foreground) !important; }
+  [data-slot='select-trigger'].pin-func-purple { background: var(--badge-purple) !important; color: var(--badge-purple-foreground) !important; }
+  [data-slot='select-trigger'].pin-func-teal { background: var(--badge-teal) !important; color: var(--badge-teal-foreground) !important; }
+  [data-slot='select-trigger'].pin-func-yellow { background: var(--badge-yellow) !important; color: var(--badge-yellow-foreground) !important; }
+  [data-slot='select-trigger'].pin-func-red { background: var(--badge-red) !important; color: var(--badge-red-foreground) !important; }
+  [data-slot='select-trigger'].pin-func-pink { background: var(--badge-pink) !important; color: var(--badge-pink-foreground) !important; }
+  [data-slot='select-trigger'].pin-func-green { background: var(--badge-green) !important; color: var(--badge-green-foreground) !important; }
+  [data-slot='select-trigger'].pin-func-gray { background: var(--badge-gray) !important; color: var(--badge-gray-foreground) !important; }
+  /* Ensure the chevron icon contrasts on colored background */
+  [data-slot='select-trigger'].pin-func-blue svg,
+  [data-slot='select-trigger'].pin-func-purple svg,
+  [data-slot='select-trigger'].pin-func-teal svg,
+  [data-slot='select-trigger'].pin-func-yellow svg,
+  [data-slot='select-trigger'].pin-func-red svg,
+  [data-slot='select-trigger'].pin-func-pink svg,
+  [data-slot='select-trigger'].pin-func-green svg,
+  [data-slot='select-trigger'].pin-func-gray svg { color: currentColor; opacity: .7; }
+  /* Reset default transparent/bg-input from trigger styling */
+  [data-slot='select-trigger'].pin-func-blue:hover,
+  [data-slot='select-trigger'].pin-func-purple:hover,
+  [data-slot='select-trigger'].pin-func-teal:hover,
+  [data-slot='select-trigger'].pin-func-yellow:hover,
+  [data-slot='select-trigger'].pin-func-red:hover,
+  [data-slot='select-trigger'].pin-func-pink:hover,
+  [data-slot='select-trigger'].pin-func-green:hover,
+  [data-slot='select-trigger'].pin-func-gray:hover { filter: brightness(0.95); }
+  .dark [data-slot='select-trigger'].pin-func-blue:hover,
+  .dark [data-slot='select-trigger'].pin-func-purple:hover,
+  .dark [data-slot='select-trigger'].pin-func-teal:hover,
+  .dark [data-slot='select-trigger'].pin-func-yellow:hover,
+  .dark [data-slot='select-trigger'].pin-func-red:hover,
+  .dark [data-slot='select-trigger'].pin-func-pink:hover,
+  .dark [data-slot='select-trigger'].pin-func-green:hover,
+  .dark [data-slot='select-trigger'].pin-func-gray:hover { filter: brightness(1.05); }
+  /* Hover: muted translucent overlay of same color */
+  .pin-func-blue:hover { background: color-mix(in oklab, var(--badge-blue) 65%, black); }
+  .pin-func-purple:hover { background: color-mix(in oklab, var(--badge-purple) 65%, black); }
+  .pin-func-teal:hover { background: color-mix(in oklab, var(--badge-teal) 65%, black); }
+  .pin-func-yellow:hover { background: color-mix(in oklab, var(--badge-yellow) 70%, black); }
+  .pin-func-red:hover { background: color-mix(in oklab, var(--badge-red) 65%, black); }
+  .pin-func-pink:hover { background: color-mix(in oklab, var(--badge-pink) 65%, black); }
+  .pin-func-green:hover { background: color-mix(in oklab, var(--badge-green) 65%, black); }
+  .pin-func-gray:hover { background: color-mix(in oklab, var(--badge-gray) 65%, black); }
+  .dark .pin-func-blue:hover { background: color-mix(in oklab, var(--badge-blue) 80%, white); }
+  .dark .pin-func-purple:hover { background: color-mix(in oklab, var(--badge-purple) 80%, white); }
+  .dark .pin-func-teal:hover { background: color-mix(in oklab, var(--badge-teal) 80%, white); }
+  .dark .pin-func-yellow:hover { background: color-mix(in oklab, var(--badge-yellow) 85%, white); }
+  .dark .pin-func-red:hover { background: color-mix(in oklab, var(--badge-red) 80%, white); }
+  .dark .pin-func-pink:hover { background: color-mix(in oklab, var(--badge-pink) 80%, white); }
+  .dark .pin-func-green:hover { background: color-mix(in oklab, var(--badge-green) 80%, white); }
+  .dark .pin-func-gray:hover { background: color-mix(in oklab, var(--badge-gray) 80%, white); }
+  /* Remove outline on selected; maintain same background */
+  .pin-func-item[data-state="checked"] { box-shadow: inset 0 0 0 1px color-mix(in oklab, currentColor 40%, transparent); }
+  /* Checkmark color consistency */
+  .pin-func-item[data-state="checked"] svg { color: currentColor; opacity: .7; }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -4,185 +4,97 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  /* Tailwind v4 token bridge (minimal). Edit core vars below in :root. */
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
   --color-card-foreground: var(--card-foreground);
   --color-popover: var(--popover);
   --color-popover-foreground: var(--popover-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
   --color-secondary: var(--secondary);
   --color-secondary-foreground: var(--secondary-foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
+  --color-destructive-foreground: var(--destructive-foreground);
   --color-success: var(--success);
   --color-success-foreground: var(--success-foreground);
   --color-warning: var(--warning);
   --color-warning-foreground: var(--warning-foreground);
   --color-info: var(--info);
   --color-info-foreground: var(--info-foreground);
-  --color-badge-yellow: var(--badge-yellow);
-  --color-badge-yellow-foreground: var(--badge-yellow-foreground);
-  --color-badge-pink: var(--badge-pink);
-  --color-badge-pink-foreground: var(--badge-pink-foreground);
-  --color-badge-blue: var(--badge-blue);
-  --color-badge-blue-foreground: var(--badge-blue-foreground);
-  --color-badge-purple: var(--badge-purple);
-  --color-badge-purple-foreground: var(--badge-purple-foreground);
-  --color-badge-teal: var(--badge-teal);
-  --color-badge-teal-foreground: var(--badge-teal-foreground);
-  --color-badge-green: var(--badge-green);
-  --color-badge-green-foreground: var(--badge-green-foreground);
-  --color-badge-red: var(--badge-red);
-  --color-badge-red-foreground: var(--badge-red-foreground);
-  --color-badge-gray: var(--badge-gray);
-  --color-badge-gray-foreground: var(--badge-gray-foreground);
+  /* Five brand colors (generic palette) */
+  --color-brand-1: var(--brand-1);
+  --color-brand-1-foreground: var(--brand-1-foreground);
+  --color-brand-2: var(--brand-2);
+  --color-brand-2-foreground: var(--brand-2-foreground);
+  --color-brand-3: var(--brand-3);
+  --color-brand-3-foreground: var(--brand-3-foreground);
+  --color-brand-4: var(--brand-4);
+  --color-brand-4-foreground: var(--brand-4-foreground);
+  --color-brand-5: var(--brand-5);
+  --color-brand-5-foreground: var(--brand-5-foreground);
 }
 
 :root {
+  /* Single-mode (dark) baseline. Edit these to change theme. */
   --radius: 0.25rem;
-  --background: oklch(0.08 0 0);
-  --foreground: oklch(0.95 0 0);
-  --card: oklch(0.12 0 0);
-  --card-foreground: oklch(0.95 0 0);
-  --popover: oklch(0.14 0 0);
-  --popover-foreground: oklch(0.95 0 0);
-  --primary: oklch(0.618 0.193 231.029);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.18 0 0);
-  --secondary-foreground: oklch(0.95 0 0);
-  --muted: oklch(0.22 0 0);
-  --muted-foreground: oklch(0.65 0 0);
-  --accent: oklch(0.25 0 0);
-  --accent-foreground: oklch(0.95 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(1 0 0 / 15%);
-  --input: oklch(1 0 0 / 20%);
-  --ring: oklch(0.618 0.193 231.029);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.1 0 0);
-  --sidebar-foreground: oklch(0.95 0 0);
-  --sidebar-primary: oklch(0.618 0.193 231.029);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.2 0 0);
-  --sidebar-accent-foreground: oklch(0.95 0 0);
-  --sidebar-border: oklch(1 0 0 / 15%);
-  --sidebar-ring: oklch(0.618 0.193 231.029);
 
-  /* HOTAS Dashboard Custom Variables */
-  --success: oklch(0.593 0.211 150.267);
-  --success-foreground: oklch(0.985 0 0);
-  --warning: oklch(0.771 0.199 85.595);
-  --warning-foreground: oklch(0.145 0 0);
-  --info: oklch(0.618 0.193 231.029);
-  --info-foreground: oklch(0.985 0 0);
-  
-  /* Badge Color Variants */
-  --badge-yellow: oklch(0.771 0.199 85.595);
-  --badge-yellow-foreground: oklch(0.145 0 0);
-  --badge-pink: oklch(0.647 0.281 10.217);
-  --badge-pink-foreground: oklch(0.985 0 0);
-  --badge-blue: oklch(0.618 0.193 231.029);
-  --badge-blue-foreground: oklch(0.985 0 0);
-  --badge-purple: oklch(0.627 0.265 303.9);
-  --badge-purple-foreground: oklch(0.985 0 0);
-  --badge-teal: oklch(0.696 0.17 162.48);
-  --badge-teal-foreground: oklch(0.985 0 0);
-  /* Extended derived variants */
-  --badge-green: var(--success);
-  --badge-green-foreground: var(--success-foreground);
-  --badge-red: var(--destructive);
-  --badge-red-foreground: oklch(0.985 0 0);
-  --badge-gray: var(--muted);
-  --badge-gray-foreground: var(--muted-foreground);
-}
-
-.dark {
+  /* Core surfaces */
   --background: #191b1d;
   --foreground: oklch(0.95 0 0);
   --card: #202427;
-  --card-foreground: oklch(0.95 0 0);
-  --popover: oklch(0.14 0 0);
-  --popover-foreground: oklch(0.95 0 0);
-  --primary: #3a4246;
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.18 0 0);
-  --secondary-foreground: oklch(0.95 0 0);
+  --card-foreground: var(--foreground);
+  --popover: #202427;
+  --popover-foreground: var(--foreground);
+
+  /* Neutrals & borders */
   --muted: oklch(0.22 0 0);
   --muted-foreground: oklch(0.65 0 0);
-  --accent: oklch(0.25 0 0);
-  --accent-foreground: oklch(0.95 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(1 0 0 / 15%);
   --input: oklch(1 0 0 / 20%);
   --ring: oklch(0.618 0.193 231.029);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: #191b1d;
-  --sidebar-foreground: oklch(0.95 0 0);
-  --sidebar-primary: oklch(0.618 0.193 231.029);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.2 0 0);
-  --sidebar-accent-foreground: oklch(0.95 0 0);
-  --sidebar-border: oklch(1 0 0 / 15%);
-  --sidebar-ring: oklch(0.618 0.193 231.029);
 
-  /* HOTAS Dashboard Dark Theme */
+  /* Semantic actions */
+  --primary: #3a4246; /* subdued primary */
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.18 0 0);
+  --secondary-foreground: var(--foreground);
+  --accent: oklch(0.25 0 0);
+  --accent-foreground: var(--foreground);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
+
+  /* Status */
   --success: oklch(0.593 0.211 150.267);
   --success-foreground: oklch(0.985 0 0);
   --warning: oklch(0.771 0.199 85.595);
   --warning-foreground: oklch(0.145 0 0);
   --info: oklch(0.618 0.193 231.029);
   --info-foreground: oklch(0.985 0 0);
-  
-  /* Badge Color Variants */
-  --badge-yellow: oklch(0.771 0.199 85.595);
-  --badge-yellow-foreground: oklch(0.985 0 0);
-  --badge-pink: oklch(0.647 0.281 10.217);
-  --badge-pink-foreground: oklch(0.985 0 0);
-  --badge-blue: oklch(0.618 0.193 231.029);
-  --badge-blue-foreground: oklch(0.985 0 0);
-  --badge-purple: oklch(0.627 0.265 303.9);
-  --badge-purple-foreground: oklch(0.985 0 0);
-  --badge-teal: oklch(0.696 0.17 162.48);
-  --badge-teal-foreground: oklch(0.985 0 0);
-  --badge-green: var(--success);
-  --badge-green-foreground: var(--success-foreground);
-  --badge-red: var(--destructive);
-  --badge-red-foreground: oklch(0.985 0 0);
-  --badge-gray: var(--muted);
-  --badge-gray-foreground: var(--muted-foreground);
+
+  /* Five brand palette (edit these for global accent diversity) */
+  --brand-1: oklch(0.618 0.193 231.029); /* blue */
+  --brand-1-foreground: oklch(0.985 0 0);
+  --brand-2: oklch(0.627 0.265 303.9);  /* purple */
+  --brand-2-foreground: oklch(0.985 0 0);
+  --brand-3: oklch(0.696 0.17 162.48);  /* teal */
+  --brand-3-foreground: oklch(0.985 0 0);
+  --brand-4: oklch(0.771 0.199 85.595); /* yellow */
+  --brand-4-foreground: oklch(0.145 0 0);
+  --brand-5: oklch(0.647 0.281 10.217); /* pink */
+  --brand-5-foreground: oklch(0.985 0 0);
+
+  /* Edit brand-1..brand-5 above to change the five accent colors used across the app.
+     These feed button/badge variants and functional color coding. Keep contrast by updating
+     the matching --brand-X-foreground if you adjust the base color. */
 }
 
 @layer base {
@@ -258,86 +170,4 @@
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 150ms;
   }
-  /* Unified Badge System */
-  .badge { @apply rounded font-mono font-bold select-none border text-[12px] flex items-center justify-center transition-colors duration-150; line-height:1; }
-  .badge[data-size="sm"] { @apply px-1.5 py-1 text-[10px]; }
-  .badge[data-size="md"] { @apply w-12 h-12; }
-  .badge[data-size="lg"] { @apply px-3 py-2 text-sm; }
-  .badge-yellow { background: var(--badge-yellow); color: var(--badge-yellow-foreground); border-color: color-mix(in oklab, var(--badge-yellow) 60%, black); }
-  .badge-pink { background: var(--badge-pink); color: var(--badge-pink-foreground); border-color: color-mix(in oklab, var(--badge-pink) 60%, black); }
-  .badge-blue { background: var(--badge-blue); color: var(--badge-blue-foreground); border-color: color-mix(in oklab, var(--badge-blue) 60%, black); }
-  .badge-purple { background: var(--badge-purple); color: var(--badge-purple-foreground); border-color: color-mix(in oklab, var(--badge-purple) 60%, black); }
-  .badge-teal { background: var(--badge-teal); color: var(--badge-teal-foreground); border-color: color-mix(in oklab, var(--badge-teal) 60%, black); }
-  .badge-green { background: var(--badge-green); color: var(--badge-green-foreground); border-color: color-mix(in oklab, var(--badge-green) 60%, black); }
-  .badge-red { background: var(--badge-red); color: var(--badge-red-foreground); border-color: color-mix(in oklab, var(--badge-red) 60%, black); }
-  .badge-gray { background: var(--badge-gray); color: var(--badge-gray-foreground); border-color: color-mix(in oklab, var(--badge-gray) 60%, black); }
-  .badge-inactive { opacity: .6; }
-  .badge-pressed { box-shadow: 0 0 0 2px color-mix(in oklab, var(--badge-red) 60%, transparent), 0 0 0 4px color-mix(in oklab, var(--badge-red) 30%, transparent); }
-  
-  /* Pin Function Dropdown Full-Row Variants */
-  .pin-func-item { @apply w-full rounded-sm px-2 py-1.5 text-xs font-mono font-semibold flex items-center gap-2 transition-colors cursor-pointer select-none; }
-  .pin-func-blue { background: var(--badge-blue); color: var(--badge-blue-foreground); }
-  .pin-func-purple { background: var(--badge-purple); color: var(--badge-purple-foreground); }
-  .pin-func-teal { background: var(--badge-teal); color: var(--badge-teal-foreground); }
-  .pin-func-yellow { background: var(--badge-yellow); color: var(--badge-yellow-foreground); }
-  .pin-func-red { background: var(--badge-red); color: var(--badge-red-foreground); }
-  .pin-func-pink { background: var(--badge-pink); color: var(--badge-pink-foreground); }
-  .pin-func-green { background: var(--badge-green); color: var(--badge-green-foreground); }
-  .pin-func-gray { background: var(--badge-gray); color: var(--badge-gray-foreground); }
-  /* Ensure trigger gets full background when variant class applied */
-  [data-slot='select-trigger'].pin-func-blue { background: var(--badge-blue) !important; color: var(--badge-blue-foreground) !important; }
-  [data-slot='select-trigger'].pin-func-purple { background: var(--badge-purple) !important; color: var(--badge-purple-foreground) !important; }
-  [data-slot='select-trigger'].pin-func-teal { background: var(--badge-teal) !important; color: var(--badge-teal-foreground) !important; }
-  [data-slot='select-trigger'].pin-func-yellow { background: var(--badge-yellow) !important; color: var(--badge-yellow-foreground) !important; }
-  [data-slot='select-trigger'].pin-func-red { background: var(--badge-red) !important; color: var(--badge-red-foreground) !important; }
-  [data-slot='select-trigger'].pin-func-pink { background: var(--badge-pink) !important; color: var(--badge-pink-foreground) !important; }
-  [data-slot='select-trigger'].pin-func-green { background: var(--badge-green) !important; color: var(--badge-green-foreground) !important; }
-  [data-slot='select-trigger'].pin-func-gray { background: var(--badge-gray) !important; color: var(--badge-gray-foreground) !important; }
-  /* Ensure the chevron icon contrasts on colored background */
-  [data-slot='select-trigger'].pin-func-blue svg,
-  [data-slot='select-trigger'].pin-func-purple svg,
-  [data-slot='select-trigger'].pin-func-teal svg,
-  [data-slot='select-trigger'].pin-func-yellow svg,
-  [data-slot='select-trigger'].pin-func-red svg,
-  [data-slot='select-trigger'].pin-func-pink svg,
-  [data-slot='select-trigger'].pin-func-green svg,
-  [data-slot='select-trigger'].pin-func-gray svg { color: currentColor; opacity: .7; }
-  /* Reset default transparent/bg-input from trigger styling */
-  [data-slot='select-trigger'].pin-func-blue:hover,
-  [data-slot='select-trigger'].pin-func-purple:hover,
-  [data-slot='select-trigger'].pin-func-teal:hover,
-  [data-slot='select-trigger'].pin-func-yellow:hover,
-  [data-slot='select-trigger'].pin-func-red:hover,
-  [data-slot='select-trigger'].pin-func-pink:hover,
-  [data-slot='select-trigger'].pin-func-green:hover,
-  [data-slot='select-trigger'].pin-func-gray:hover { filter: brightness(0.95); }
-  .dark [data-slot='select-trigger'].pin-func-blue:hover,
-  .dark [data-slot='select-trigger'].pin-func-purple:hover,
-  .dark [data-slot='select-trigger'].pin-func-teal:hover,
-  .dark [data-slot='select-trigger'].pin-func-yellow:hover,
-  .dark [data-slot='select-trigger'].pin-func-red:hover,
-  .dark [data-slot='select-trigger'].pin-func-pink:hover,
-  .dark [data-slot='select-trigger'].pin-func-green:hover,
-  .dark [data-slot='select-trigger'].pin-func-gray:hover { filter: brightness(1.05); }
-  /* Hover: muted translucent overlay of same color */
-  .pin-func-blue:hover { background: color-mix(in oklab, var(--badge-blue) 65%, black); }
-  .pin-func-purple:hover { background: color-mix(in oklab, var(--badge-purple) 65%, black); }
-  .pin-func-teal:hover { background: color-mix(in oklab, var(--badge-teal) 65%, black); }
-  .pin-func-yellow:hover { background: color-mix(in oklab, var(--badge-yellow) 70%, black); }
-  .pin-func-red:hover { background: color-mix(in oklab, var(--badge-red) 65%, black); }
-  .pin-func-pink:hover { background: color-mix(in oklab, var(--badge-pink) 65%, black); }
-  .pin-func-green:hover { background: color-mix(in oklab, var(--badge-green) 65%, black); }
-  .pin-func-gray:hover { background: color-mix(in oklab, var(--badge-gray) 65%, black); }
-  .dark .pin-func-blue:hover { background: color-mix(in oklab, var(--badge-blue) 80%, white); }
-  .dark .pin-func-purple:hover { background: color-mix(in oklab, var(--badge-purple) 80%, white); }
-  .dark .pin-func-teal:hover { background: color-mix(in oklab, var(--badge-teal) 80%, white); }
-  .dark .pin-func-yellow:hover { background: color-mix(in oklab, var(--badge-yellow) 85%, white); }
-  .dark .pin-func-red:hover { background: color-mix(in oklab, var(--badge-red) 80%, white); }
-  .dark .pin-func-pink:hover { background: color-mix(in oklab, var(--badge-pink) 80%, white); }
-  .dark .pin-func-green:hover { background: color-mix(in oklab, var(--badge-green) 80%, white); }
-  .dark .pin-func-gray:hover { background: color-mix(in oklab, var(--badge-gray) 80%, white); }
-  /* Remove outline on selected; maintain same background */
-  .pin-func-item[data-state="checked"] { box-shadow: inset 0 0 0 1px color-mix(in oklab, currentColor 40%, transparent); }
-  /* Checkmark color consistency */
-  .pin-func-item[data-state="checked"] svg { color: currentColor; opacity: .7; }
 }


### PR DESCRIPTION
This pull request refactors and standardizes the usage of badge components across the codebase, introducing a new `Badge` component with a consistent set of variants and updating all related UI elements to use the new design tokens. It also replaces legacy color variants with new brand and status variants, improves accessibility and maintainability, and removes custom color logic in favor of centralized styling.

**Badge component and variant system overhaul:**

* Added a new `Badge` component (`src/components/Badge.tsx`) that wraps the UI badge and provides a unified API for size and variant, mapping legacy and new variants to a standardized set. (`[src/components/Badge.tsxR1-R46](diffhunk://#diff-330ae9ac68f256152f4928076dd4aa73a19e43692445d932b10e2eb4587b35baR1-R46)`)
* Introduced a centralized variant system in `badge-variants.ts` with brand and status colors, replacing legacy variants and making badges easier to style and maintain. (`[src/components/ui/badge-variants.tsR1-R29](diffhunk://#diff-735033d70465ee3ddc263aa9f93b0c3706d7c50720c1e69461aaff844b55a5ceR1-R29)`)
* Updated the underlying UI badge to use the new variant system and removed legacy color logic from `badge.tsx`. (`[src/components/ui/badge.tsxL3-R6](diffhunk://#diff-6d99361c2e374eb2dd472d6136d9d5929c8f32128cbb0b6ab8bdafea6beca6aeL3-R6)`)

**Refactoring badge usage in feature components:**

* Refactored `ButtonStateBadge`, `RawPinStateBadge`, and `RawStateBadge` components to use the new `Badge` component and standardized variants for all states, improving consistency and accessibility. (`[[1]](diffhunk://#diff-38c79db135980505ff850a9a785754111fc95e599f6769e012af4c19249c3ae8R2-R3)`, `[[2]](diffhunk://#diff-38c79db135980505ff850a9a785754111fc95e599f6769e012af4c19249c3ae8R12-R37)`, `[[3]](diffhunk://#diff-af1f2691c6e0794f82bf3a46f9531fa2a245001eafd3ebd7043058191335877cR3)`, `[[4]](diffhunk://#diff-af1f2691c6e0794f82bf3a46f9531fa2a245001eafd3ebd7043058191335877cL16-R17)`, `[[5]](diffhunk://#diff-af1f2691c6e0794f82bf3a46f9531fa2a245001eafd3ebd7043058191335877cL48-R54)`, `[[6]](diffhunk://#diff-af1f2691c6e0794f82bf3a46f9531fa2a245001eafd3ebd7043058191335877cL85-R82)`, `[[7]](diffhunk://#diff-cfd105a1538769f99bc35f8986012c00f6f4f2d4473792750aaa4b0368d13ae8R3-R4)`, `[[8]](diffhunk://#diff-cfd105a1538769f99bc35f8986012c00f6f4f2d4473792750aaa4b0368d13ae8L34-R59)`)
* Updated device and sidebar update indicators to use the new `brand4` variant for "Update Available" badges. (`[[1]](diffhunk://#diff-22316746eafa90f60639230f7234db399ce36f1cf233d842ad497f97b458c575L160-R160)`, `[[2]](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cL231-R231)`)

**Pin configuration and documentation updates:**

* Refactored `PinDropdown` to use utility classes for badge colors instead of the old badge component, mapping pin functions to brand/status colors for better clarity and consistency. (`[[1]](diffhunk://#diff-9f327d8137b239640ff00935d8dce3dccf2e110f20ff08245a520363a26bb440L9-R36)`, `[[2]](diffhunk://#diff-9f327d8137b239640ff00935d8dce3dccf2e110f20ff08245a520363a26bb440L120-R156)`)
* Updated documentation badges in `PinoutConfiguration` to use new brand variants, aligning the UI with the new badge system. (`[src/components/PinoutConfiguration.tsxL216-R243](diffhunk://#diff-fcd4b26a0cb546b22cd637865308c1b5355f7171865ed451031dee9fa5c9180fL216-R243)`)

**Pinout and SVG visualization improvements:**

* Updated pinout visualizations in `PicoSVG` to use new brand and status variants, improving clarity of pin roles and states in the UI. (`[[1]](diffhunk://#diff-6ca166d91b69238c9539e0a999df75e20dd1b39cad3f9810a347e803f1a4ffecL105-R109)`, `[[2]](diffhunk://#diff-6ca166d91b69238c9539e0a999df75e20dd1b39cad3f9810a347e803f1a4ffecL141-R145)`)